### PR TITLE
fix: disable async background flush of traces

### DIFF
--- a/pytest_mergify/__init__.py
+++ b/pytest_mergify/__init__.py
@@ -37,14 +37,20 @@ class PytestMergify:
         # sure that we capture the possible error logs, otherwise they are
         # emitted on exit (atexit()).
         if self.mergify_tracer.tracer_provider is not None:
-            self.mergify_tracer.tracer_provider.shutdown()  # type: ignore[no-untyped-call]
-
-        if self.mergify_tracer.log_handler.log_list:
-            terminalreporter.write_line(
-                "There are been some errors reported by the tracer:", red=True
-            )
-            for line in self.mergify_tracer.log_handler.log_list:
-                terminalreporter.write_line(line)
+            try:
+                self.mergify_tracer.tracer_provider.force_flush()
+            except Exception as e:
+                terminalreporter.write_line(
+                    f"Error while exporting traces: {e}",
+                    red=True,
+                )
+            try:
+                self.mergify_tracer.tracer_provider.shutdown()  # type: ignore[no-untyped-call]
+            except Exception as e:
+                terminalreporter.write_line(
+                    f"Error while shutting down the tracer: {e}",
+                    red=True,
+                )
 
         if self.mergify_tracer.token is None:
             terminalreporter.write_line(

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -116,4 +116,9 @@ def test_errors_logs(
     )
     result = pytester.runpytest_subprocess()
     result.assert_outcomes(passed=1)
-    assert "There are been some errors reported by the tracer:" in result.stdout.lines
+    assert any(
+        line.startswith(
+            "Error while exporting traces: HTTPConnectionPool(host='localhost', port=9999): Max retries exceeded with url"
+        )
+        for line in result.stdout.lines
+    )


### PR DESCRIPTION
When running in complex test suite that mocks many things, trying to
flush in the background traces does not work. For example network
requests might be mocked, or time might be mocked, making SSL connection
impossible.

This stores the span in memory until a flush is requested at the end of
pytest.

This also means there is no way to capture the opentelemetry log in the
background are we can now intercept any error raised by the code while
flushing the traces.