### PR TITLE
test: refactor plugin setup

### DIFF
--- a/pytest_mergify/__init__.py
+++ b/pytest_mergify/__init__.py
@@ -1,5 +1,3 @@
-import typing
-
 import pytest
 import _pytest.main
 import _pytest.config
@@ -12,21 +10,16 @@ from pytest_mergify.tracer import MergifyTracer
 
 
 class PytestMergify:
-    __name__ = "PytestMergify"
-
     mergify_tracer: MergifyTracer
 
     # Do this after pytest-opentelemetry has setup things
     @pytest.hookimpl(trylast=True)
     def pytest_configure(self, config: _pytest.config.Config) -> None:
+        kwargs = {}
         api_url = config.getoption("--mergify-api-url")
-        if api_url is None:
-            self.reconfigure()
-        else:
-            self.reconfigure(api_url=api_url)
-
-    def reconfigure(self, *args: typing.Any, **kwargs: typing.Any) -> None:
-        self.mergify_tracer = MergifyTracer(*args, **kwargs)
+        if api_url is not None:
+            kwargs["api_url"] = api_url
+        self.mergify_tracer = MergifyTracer(**kwargs)
 
     def pytest_terminal_summary(
         self, terminalreporter: _pytest.terminal.TerminalReporter
@@ -92,4 +85,4 @@ def pytest_addoption(parser: _pytest.config.argparsing.Parser) -> None:
 
 
 def pytest_configure(config: _pytest.config.Config) -> None:
-    config.pluginmanager.register(PytestMergify())
+    config.pluginmanager.register(PytestMergify(), name="PytestMergify")

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,82 +1,46 @@
-import _pytest.pytester
-import _pytest.config
+import re
+import typing
+
+import pytest
 
 
 from tests import conftest
 
+from pytest_mergify import utils
+
 
 def test_span_resources_attributes_ci(
-    pytester: _pytest.pytester.Pytester,
-    reconfigure_mergify_tracer: conftest.ReconfigureT,
+    pytester_with_spans: conftest.PytesterWithSpanT,
 ) -> None:
-    reconfigure_mergify_tracer({"_PYTEST_MERGIFY_TEST": "true"})
-    pytester.makepyfile(
-        """
-        import pytest
-
-        from pytest_mergify import utils
-
-        def test_span(pytestconfig):
-            plugin = pytestconfig.pluginmanager.get_plugin("PytestMergify")
-            assert plugin is not None
-            assert plugin.mergify_tracer.exporter is not None
-            spans = plugin.mergify_tracer.exporter.get_finished_spans()
-            assert spans[0].resource.attributes["cicd.provider.name"] == utils.get_ci_provider()
-        """
+    result, spans = pytester_with_spans()
+    assert all(
+        span.resource.attributes["cicd.provider.name"] == utils.get_ci_provider()
+        for span in spans
     )
-    result = pytester.runpytest_subprocess()
-    result.assert_outcomes(passed=1)
 
 
 def test_span_resources_attributes_pytest(
-    pytester: _pytest.pytester.Pytester,
-    reconfigure_mergify_tracer: conftest.ReconfigureT,
+    pytester_with_spans: conftest.PytesterWithSpanT,
 ) -> None:
-    reconfigure_mergify_tracer({"_PYTEST_MERGIFY_TEST": "true"})
-    pytester.makepyfile(
-        """
-        import re
-
-        import pytest
-
-        def test_span(pytestconfig):
-            plugin = pytestconfig.pluginmanager.get_plugin("PytestMergify")
-            assert plugin is not None
-            assert plugin.mergify_tracer.exporter is not None
-            spans = plugin.mergify_tracer.exporter.get_finished_spans()
-            assert spans[0].resource.attributes["test.framework"] == "pytest"
-            assert re.match(r"\d\.", spans[0].resource.attributes["test.framework.version"])
-        """
+    result, spans = pytester_with_spans()
+    assert all(
+        re.match(
+            r"\d\.",
+            typing.cast(str, span.resource.attributes["test.framework.version"]),
+        )
+        for span in spans
     )
-    result = pytester.runpytest_subprocess()
-    result.assert_outcomes(passed=1)
 
 
 def test_span_github_actions(
-    pytester: _pytest.pytester.Pytester,
-    reconfigure_mergify_tracer: conftest.ReconfigureT,
+    monkeypatch: pytest.MonkeyPatch,
+    pytester_with_spans: conftest.PytesterWithSpanT,
 ) -> None:
     # Do a partial reconfig, half GHA, half local to have spans
-    reconfigure_mergify_tracer(
-        {
-            "GITHUB_ACTIONS": "true",
-            "GITHUB_REPOSITORY": "Mergifyio/pytest-mergify",
-            "_PYTEST_MERGIFY_TEST": "true",
-        },
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "Mergifyio/pytest-mergify")
+    result, spans = pytester_with_spans()
+    assert (
+        spans[0].resource.attributes["vcs.repository.name"]
+        == "Mergifyio/pytest-mergify"
     )
-    pytester.makepyfile(
-        """
-        import pytest
-
-        from pytest_mergify import utils
-
-        def test_span(pytestconfig):
-            plugin = pytestconfig.pluginmanager.get_plugin("PytestMergify")
-            assert plugin is not None
-            assert plugin.mergify_tracer.exporter is not None
-            spans = plugin.mergify_tracer.exporter.get_finished_spans()
-            assert spans[0].resource.attributes["vcs.repository.name"] == "Mergifyio/pytest-mergify"
-        """
-    )
-    result = pytester.runpytest_subprocess()
-    result.assert_outcomes(passed=1)

--- a/tests/test_spans.py
+++ b/tests/test_spans.py
@@ -1,27 +1,12 @@
-import _pytest.pytester
-import _pytest.config
-
 from tests import conftest
 
 
 def test_span(
-    pytester: _pytest.pytester.Pytester,
-    reconfigure_mergify_tracer: conftest.ReconfigureT,
+    pytester_with_spans: conftest.PytesterWithSpanT,
 ) -> None:
-    reconfigure_mergify_tracer({"_PYTEST_MERGIFY_TEST": "true"})
-    pytester.makepyfile(
-        """
-        import pytest
-
-        from pytest_mergify import utils
-
-        def test_span(pytestconfig):
-            plugin = pytestconfig.pluginmanager.get_plugin("PytestMergify")
-            assert plugin is not None
-            assert plugin.mergify_tracer.exporter is not None
-            spans = plugin.mergify_tracer.exporter.get_finished_spans()
-            assert any(s.name == "pytestconfig setup" for s in spans)
-        """
-    )
-    result = pytester.runpytest_subprocess()
-    result.assert_outcomes(passed=1)
+    result, spans = pytester_with_spans()
+    assert any(s.name == "test run" for s in spans)
+    assert any(s.name == "test_span.py::test_pass" for s in spans)
+    assert any(s.name == "test_span.py::test_pass::setup" for s in spans)
+    assert any(s.name == "test_span.py::test_pass::call" for s in spans)
+    assert any(s.name == "test_span.py::test_pass::teardown" for s in spans)


### PR DESCRIPTION
I found out you can actually pass plugin instance to pytester when
running it inline: this means we can grab the list of spans in a
sub-pytest if we run it inline.

This simplifies the overall architecture to split the tests in two mode:
- either we run them in a subprocess to test the whole lifecycle (e.g.
  upload errors are printed)
- either we run them inprocess and we can read the list of spans

This will make it easier in the future to replace pytest-opentelemetry
and test the spans that are emitted.