### PR TITLE
test: move resource test outside of resource

### DIFF
--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -55,13 +55,3 @@ def test_span_github_actions(
         span.resource.attributes["cicd.pipeline.run.id"] == 3213121312
         for span in spans.values()
     )
-
-
-def test_span_resources_attributes_mergify(
-    pytester_with_spans: conftest.PytesterWithSpanT,
-) -> None:
-    result, spans = pytester_with_spans()
-    assert all(
-        isinstance(span.resource.attributes["test.run.id"], int)
-        for span in spans.values()
-    )

--- a/tests/test_spans.py
+++ b/tests/test_spans.py
@@ -245,3 +245,13 @@ test_fixture_failure.py:3: Exception""",
         spans["test_fixture_failure.py::test_pass"].status.description
         == "<class 'Exception'>: HELLO"
     )
+
+
+def test_span_resources_test_run_id(
+    pytester_with_spans: conftest.PytesterWithSpanT,
+) -> None:
+    result, spans = pytester_with_spans()
+    assert all(
+        isinstance(span.resource.attributes["test.run.id"], int)
+        for span in spans.values()
+    )


### PR DESCRIPTION
We moved this to be a tracer builtin.