### PR TITLE
fix: set test.run.id as str

### DIFF
--- a/pytest_mergify/__init__.py
+++ b/pytest_mergify/__init__.py
@@ -65,7 +65,7 @@ class PytestMergify:
 
         if utils.get_ci_provider() == "github_actions":
             terminalreporter.write_line(
-                f"::notice title=Mergify CI::MERGIFY_TEST_RUN_ID={self.mergify_tracer.test_run_id.to_bytes(8, 'big').hex()}",
+                f"::notice title=Mergify CI::MERGIFY_TEST_RUN_ID={self.mergify_tracer.test_run_id}",
             )
 
     @property

--- a/pytest_mergify/tracer.py
+++ b/pytest_mergify/tracer.py
@@ -52,7 +52,9 @@ class MergifyTracer:
     tracer_provider: opentelemetry.sdk.trace.TracerProvider | None = dataclasses.field(
         init=False, default=None
     )
-    test_run_id: int = dataclasses.field(default_factory=lambda: random.getrandbits(64))
+    test_run_id: str = dataclasses.field(
+        default_factory=lambda: random.getrandbits(64).to_bytes(8, "big").hex()
+    )
 
     def __post_init__(self) -> None:
         span_processor: SpanProcessor

--- a/tests/test_spans.py
+++ b/tests/test_spans.py
@@ -252,6 +252,8 @@ def test_span_resources_test_run_id(
 ) -> None:
     result, spans = pytester_with_spans()
     assert all(
-        isinstance(span.resource.attributes["test.run.id"], int)
+        isinstance(span.resource.attributes["test.run.id"], str)
+        and len(span.resource.attributes["test.run.id"]) == 16
+        and int(span.resource.attributes["test.run.id"], 16) > 0
         for span in spans.values()
     )


### PR DESCRIPTION
OpenTelemetry does not know how to encode a 8 bytes integer in protobuf,
so it fails. Since the Python framework does not want us to use bytes,
we'll use a str with hex format.