### PR TITLE
fix: print errors on != 200

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -865,4 +865,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.8"
-content-hash = "26742b728196f5c44c18dae8417a6d11601020354d87745c162654bcfceb5e79"
+content-hash = "fb7f2cd79efbd7a5db5cd3e3a559e498ef25331a3b71ceeecc5f405352f76c18"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ python = ">=3.8"
 # We set this version explicitly to avoid breaking changes
 opentelemetry-exporter-otlp-proto-http = ">=1.25"
 opentelemetry-sdk = ">=1.25"
+requests = "^2.32.3"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
The OTLPSpanExporter exporter ignores non-200 errors and does not print
anything. This makes sure we have an exception.

types-requests is not installable on Python 3.8 so we just ignore typing. Not a
big deal considering how we use requests here.