### PR TITLE
fix: pytest --help

### DIFF
--- a/pytest_mergify/__init__.py
+++ b/pytest_mergify/__init__.py
@@ -199,7 +199,7 @@ def pytest_addoption(parser: _pytest.config.argparsing.Parser) -> None:
     group.addoption(
         "--mergify-api-url",
         help=(
-            "URL of the Mergify API (or set via MERGIFY_API_URL environment variable)",
+            "URL of the Mergify API (or set via MERGIFY_API_URL environment variable)"
         ),
     )
 


### PR DESCRIPTION
help should be a `str` not a `tuple` otherwise it breaks `pytest --help`

Before the fix `pytest --help` is exiting with the following error
```
    if action.help and action.help.strip():
                       ^^^^^^^^^^^^^^^^^
AttributeError: 'tuple' object has no attribute 'strip'
```

After the fix `pytest --help` is working as usual
