### PR TITLE
fix: add pytest into dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ python = ">=3.8"
 opentelemetry-exporter-otlp-proto-http = ">=1.25"
 opentelemetry-sdk = ">=1.25"
 requests = "^2.32.3"
+pytest = ">=8.0"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
so after pip install pytest-mergify  in a new environment, it would be importable; since otherwise import would just crash.

I do appreciate the fact that this package is intended to be used with pytest and nobody should install/use without pytest, but IMHO this way it would be more kosher
