### PR TITLE
chore: add support PYTEST_MERGIFY_ENABLED=true

### DIFF
--- a/pytest_mergify/utils.py
+++ b/pytest_mergify/utils.py
@@ -12,7 +12,9 @@ SUPPORTED_CIs: typing.Dict[str, CIProviderT] = {
 
 
 def is_in_ci() -> bool:
-    return strtobool(os.environ.get("CI", "false"))
+    return strtobool(os.environ.get("CI", "false")) or strtobool(
+        os.environ.get("PYTEST_MERGIFY_ENABLE", "false")
+    )
 
 
 def get_ci_provider() -> typing.Optional[CIProviderT]:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -21,6 +21,18 @@ def test_no_ci(pytester_with_spans: conftest.PytesterWithSpanT) -> None:
     assert all("Mergify" not in line for line in result.stdout.lines)
 
 
+@pytest.mark.parametrize("env", ("PYTEST_MERGIFY_ENABLED", "CI"))
+def test_enabled(
+    env: str,
+    pytester_with_spans: conftest.PytesterWithSpanT,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("CI", raising=False)
+    result, spans = pytester_with_spans(setenv={env: "true"})
+    assert spans is not None
+    assert any("Mergify CI" in line for line in result.stdout.lines)
+
+
 def test_no_token(pytester_with_spans: conftest.PytesterWithSpanT) -> None:
     result, spans = pytester_with_spans()
     assert spans is not None


### PR DESCRIPTION
CI=true is good to enable it by default in CI. But some tests may change
their behavior when CI is set.

For example in pytest, they use tox and ensure CI is not passed
to the test suite. Enabling pytest-mergify breaks the test suite.

This change introduces an alternative for user that can't rely
on CI=true.