### PR TITLE
refactor: remove invalid `code.function.name` usage

### DIFF
--- a/pytest_mergify/__init__.py
+++ b/pytest_mergify/__init__.py
@@ -113,7 +113,6 @@ class PytestMergify:
             SpanAttributes.CODE_FUNCTION: item.name,
             SpanAttributes.CODE_LINENO: line_number or 0,
             SpanAttributes.CODE_NAMESPACE: namespace,
-            "code.function.name": item.nodeid,
             "code.file.path": str(_pytest.pathlib.absolutepath(item.reportinfo()[0])),
             "code.line.number": line_number or 0,
         }

--- a/tests/test_spans.py
+++ b/tests/test_spans.py
@@ -53,7 +53,6 @@ def test_test(
         "code.namespace": "",
         "test.case.result.status": "passed",
         "code.file.path": anys.ANY_STR,
-        "code.function.name": "test_test.py::test_pass",
         "code.line.number": 0,
     }
     assert (
@@ -89,7 +88,6 @@ E   assert False
 
 test_test_failure.py:1: AssertionError""",
         "code.file.path": anys.ANY_STR,
-        "code.function.name": "test_test_failure.py::test_error",
         "code.line.number": 0,
     }
     assert (
@@ -127,7 +125,6 @@ def test_skipped():
         "code.filepath": "test_test_skipped.py",
         "code.namespace": "",
         "code.file.path": anys.ANY_STR,
-        "code.function.name": "test_test_skipped.py::test_skipped",
         "code.line.number": 1,
     }
     assert (
@@ -173,7 +170,6 @@ def test_skipped():
         "code.filepath": "test_mark_skipped.py",
         "code.namespace": "",
         "code.file.path": anys.ANY_STR,
-        "code.function.name": "test_mark_skipped.py::test_skipped",
         "code.line.number": 1,
     }
     assert (
@@ -208,7 +204,6 @@ def test_not_skipped():
         "code.filepath": "test_mark_not_skipped.py",
         "code.namespace": "",
         "code.file.path": anys.ANY_STR,
-        "code.function.name": "test_mark_not_skipped.py::test_not_skipped",
         "code.line.number": 1,
     }
     assert (


### PR DESCRIPTION
This is meant to be a python valid syntax of the module leading to the
function, however `item.nodeid` is just the pytest representation of the
test, which is not a proper python syntax for the function.

Depends-On: #136