### PR TITLE
chore: add a git Detector

### DIFF
--- a/pytest_mergify/ci_insights.py
+++ b/pytest_mergify/ci_insights.py
@@ -1,27 +1,26 @@
 import dataclasses
-import _pytest.nodes
-import random
 import os
+import random
 import typing
 
-import requests
+import _pytest.nodes
 import opentelemetry.sdk.resources
-from opentelemetry.sdk.trace import export
-from opentelemetry.sdk.trace import TracerProvider, SpanProcessor, ReadableSpan
+import requests
 from opentelemetry.exporter.otlp.proto.http import Compression
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
     OTLPSpanExporter,
 )
-
-from pytest_mergify import utils
-import pytest_mergify.quarantine
-
-import pytest_mergify.resources.ci as resources_ci
+from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor, TracerProvider, export
 from opentelemetry.semconv._incubating.attributes import vcs_attributes
+
+import pytest_mergify.quarantine
+import pytest_mergify.resources.ci as resources_ci
+import pytest_mergify.resources.git as resources_git
 import pytest_mergify.resources.github_actions as resources_gha
-import pytest_mergify.resources.pytest as resources_pytest
-import pytest_mergify.resources.mergify as resources_mergify
 import pytest_mergify.resources.jenkins as resources_jenkins
+import pytest_mergify.resources.mergify as resources_mergify
+import pytest_mergify.resources.pytest as resources_pytest
+from pytest_mergify import utils
 
 
 class SynchronousBatchSpanProcessor(export.SimpleSpanProcessor):
@@ -116,6 +115,7 @@ class MergifyCIInsights:
 
         resource = opentelemetry.sdk.resources.get_aggregated_resources(
             [
+                resources_git.GitResourceDetector(),
                 resources_ci.CIResourceDetector(),
                 resources_gha.GitHubActionsResourceDetector(),
                 resources_jenkins.JenkinsResourceDetector(),

--- a/pytest_mergify/resources/git.py
+++ b/pytest_mergify/resources/git.py
@@ -1,0 +1,43 @@
+import typing
+
+from opentelemetry.sdk.resources import Resource, ResourceDetector
+from opentelemetry.semconv._incubating.attributes import vcs_attributes
+
+from pytest_mergify import utils
+
+
+def _get_git_commit() -> typing.Optional[str]:
+    return utils.git("rev-parse", "HEAD")
+
+
+def _get_git_branch() -> typing.Optional[str]:
+    return utils.git("rev-parse", "--abbrev-ref", "HEAD")
+
+
+def _get_git_url() -> typing.Optional[str]:
+    return utils.git("config", "--get", "remote.origin.url")
+
+
+def _get_repository_name() -> typing.Optional[str]:
+    repository_url = _get_git_url()
+    if repository_url:
+        utils.get_repository_name_from_url(repository_url)
+    return None
+
+
+class GitResourceDetector(ResourceDetector):
+    """Detects OpenTelemetry Resource attributes for GitHub Actions."""
+
+    OPENTELEMETRY_GIT_MAPPING = {
+        vcs_attributes.VCS_REF_HEAD_NAME: (str, _get_git_branch),
+        vcs_attributes.VCS_REF_HEAD_REVISION: (str, _get_git_commit),
+        vcs_attributes.VCS_REPOSITORY_URL_FULL: (str, _get_git_url),
+        "vcs.repository.name": (str, _get_repository_name),
+    }
+
+    def detect(self) -> Resource:
+        if utils.get_ci_provider() is None:
+            return Resource({})
+
+        attributes = utils.get_attributes(self.OPENTELEMETRY_GIT_MAPPING)
+        return Resource(attributes)

--- a/pytest_mergify/resources/jenkins.py
+++ b/pytest_mergify/resources/jenkins.py
@@ -5,6 +5,7 @@ from opentelemetry.sdk.resources import Resource, ResourceDetector
 from opentelemetry.semconv._incubating.attributes import cicd_attributes, vcs_attributes
 
 from pytest_mergify import utils
+from pytest_mergify.resources import git
 
 GIT_BRANCH_PREFIXES = ("origin/", "refs/heads/")
 
@@ -44,5 +45,9 @@ class JenkinsResourceDetector(ResourceDetector):
         if utils.get_ci_provider() != "jenkins":
             return Resource({})
 
-        attributes = utils.get_attributes(self.OPENTELEMETRY_JENKINS_MAPPING)
+        attributes = utils.get_attributes(
+            git.GitResourceDetector.OPENTELEMETRY_GIT_MAPPING
+        )
+        attributes.update(utils.get_attributes(self.OPENTELEMETRY_JENKINS_MAPPING))
+
         return Resource(attributes)


### PR DESCRIPTION
Depending on how Jenkins checkout the code we may not have the GIT_*
envs.

This change creates a git provider that pick the data from the local
checked git.