### PR TITLE
chore(deps): bump dependencies versions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -865,4 +865,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.8"
-content-hash = "e31b2e7ab1d5e5972b3d35017b95f10f8ee1831e2e0eeef1573ec2f47a21884b"
+content-hash = "af238415973d86ae379bae3f76e7554e0dbbcf2d62687517304f8be181d28a65"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,15 +11,15 @@ python = ">=3.8"
 # We set this version explicitly to avoid breaking changes
 opentelemetry-exporter-otlp-proto-http = ">=1.25"
 opentelemetry-sdk = ">=1.25"
-requests = ">=2"
+requests = ">=2.32"
 pytest = ">=6.0.0"
 
 
 [tool.poetry.group.dev.dependencies]
 ruff = ">=0.12,<0.13.0"
-mypy = "^1.13.0"
+mypy = "^1.14.0"
 poethepoet = ">=0.30"
-codespell = "^2.3.0"
+codespell = "^2.4.1"
 yamllint = "^1.35.1"
 anys = "^0.3.1"
 


### PR DESCRIPTION
- `requests>=2` -> `requests>=2.32`
- `mypy = ^1.13.30` -> `mypy = ^1.14.0`
- `codespell = ^2.3.0` -> `codespell = ^2.4.1`