### PR TITLE
refactor: MergifyTracer should be MergifyCIInsights

### DIFF
--- a/pytest_mergify/ci_insights.py
+++ b/pytest_mergify/ci_insights.py
@@ -48,7 +48,7 @@ class SessionHardRaiser(requests.Session):  # type: ignore[misc]
 
 
 @dataclasses.dataclass
-class MergifyTracer:
+class MergifyCIInsights:
     token: typing.Optional[str] = dataclasses.field(
         default_factory=lambda: os.environ.get("MERGIFY_TOKEN")
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,8 +64,8 @@ def pytester_with_spans(
         spans_as_dict: typing.Optional[typing.Dict[str, ReadableSpan]]
         if code is _DEFAULT_PYTESTER_CODE:
             result.assert_outcomes(passed=1)
-        if isinstance(plugin.mergify_tracer.exporter, InMemorySpanExporter):
-            spans = plugin.mergify_tracer.exporter.get_finished_spans()
+        if isinstance(plugin.mergify_ci.exporter, InMemorySpanExporter):
+            spans = plugin.mergify_ci.exporter.get_finished_spans()
             spans_as_dict = {span.name: span for span in spans}
             # Make sure we don't lose spans in the process
             assert len(spans_as_dict) == len(spans)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -100,7 +100,7 @@ def test_repo_name_github_actions(
     plugin = pytest_mergify.PytestMergify()
     pytester.makepyfile("")
     pytester.runpytest_inprocess(plugins=[plugin])
-    assert plugin.mergify_tracer.repo_name == "Mergifyio/pytest-mergify"
+    assert plugin.mergify_ci.repo_name == "Mergifyio/pytest-mergify"
 
 
 def test_with_token_empty_repo(


### PR DESCRIPTION
It now represents the instance of an access to CI Insights, and still
manage the tracer as needed.