### PR TITLE
feat(span): exception name instead of class repr for error_type

### DIFF
--- a/pytest_mergify/__init__.py
+++ b/pytest_mergify/__init__.py
@@ -220,7 +220,7 @@ class PytestMergify:
 
             test_span.set_attributes(
                 {
-                    SpanAttributes.EXCEPTION_TYPE: str(excinfo.type),
+                    SpanAttributes.EXCEPTION_TYPE: str(excinfo.type.__name__),
                     SpanAttributes.EXCEPTION_MESSAGE: str(excinfo.value),
                     SpanAttributes.EXCEPTION_STACKTRACE: str(report.longrepr),
                 }

--- a/tests/test_spans.py
+++ b/tests/test_spans.py
@@ -101,7 +101,7 @@ def test_test_failure(
         "code.lineno": 0,
         "code.filepath": "test_test_failure.py",
         "code.namespace": "",
-        SpanAttributes.EXCEPTION_TYPE: "<class 'AssertionError'>",
+        SpanAttributes.EXCEPTION_TYPE: "AssertionError",
         SpanAttributes.EXCEPTION_MESSAGE: "foobar\nassert False",
         SpanAttributes.EXCEPTION_STACKTRACE: """>   def test_error(): assert False, 'foobar'
 E   AssertionError: foobar


### PR DESCRIPTION
Class name instead of representation is more readable