### PR TITLE
feat(ci-insights): Parse `MERGIFY_TEST_FLAKY_DETECTION_ENABLED` variable

### DIFF
--- a/pytest_mergify/resources/mergify.py
+++ b/pytest_mergify/resources/mergify.py
@@ -7,6 +7,10 @@ class MergifyResourceDetector(ResourceDetector):
     """Detects OpenTelemetry Resource attributes for Mergify fields."""
 
     OPENTELEMETRY_MERGIFY_MAPPING = {
+        "mergify.test.flaky_detection_enabled": (
+            str,
+            "MERGIFY_TEST_FLAKY_DETECTION_ENABLED",
+        ),
         "mergify.test.job.name": (str, "MERGIFY_TEST_JOB_NAME"),
     }
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -37,9 +37,15 @@ def test_span_resources_attributes_mergify(
     pytester_with_spans: conftest.PytesterWithSpanT,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setenv("MERGIFY_TEST_FLAKY_DETECTION_ENABLED", "true")
     monkeypatch.setenv("MERGIFY_TEST_JOB_NAME", "f00b4r")
+
     result, spans = pytester_with_spans()
     assert spans is not None
+    assert all(
+        span.resource.attributes["mergify.test.flaky_detection_enabled"] == "true"
+        for span in spans.values()
+    )
     assert all(
         span.resource.attributes["mergify.test.job.name"] == "f00b4r"
         for span in spans.values()


### PR DESCRIPTION
This variable is used to set the `mergify.test.flaky_detection_enabled`
field to OpenTelemetry spans. This field will then be used to know which
user has configured flaky test detection.

Fixes: MRGFY-5753