### PR TITLE
fix(ci-insights): Support all report outcomes when running flaky test detections

### DIFF
--- a/pytest_mergify/ci_insights.py
+++ b/pytest_mergify/ci_insights.py
@@ -249,7 +249,8 @@ class MergifyCIInsights:
                 if report.when != "call":
                     continue
 
-                outcomes[report.outcome] += 1
+                if report.outcome in ("failed", "passed"):
+                    outcomes[report.outcome] += 1
 
         # NOTE(remyduthu): We execute all tests a first time to detect newly
         # added tests. We might want to include the outcome of the first run in


### PR DESCRIPTION
Relates-To: MRGFY-5827

Depends-On: #189