### PR TITLE
fix: Register only one plugin

### DIFF
--- a/pytest_mergify/__init__.py
+++ b/pytest_mergify/__init__.py
@@ -305,6 +305,14 @@ def pytest_addoption(parser: _pytest.config.argparsing.Parser) -> None:
 
 
 def pytest_configure(config: _pytest.config.Config) -> None:
+    # NOTE(remyduthu):
+    # We are using `isinstance` instead of `get_plugin` because the plugin can
+    # be registered with a different name (e.g. `pytester`). It feels safer to
+    # check the class name directly.
+    for plugin in config.pluginmanager.get_plugins():
+        if isinstance(plugin, PytestMergify):
+            return
+
     config.pluginmanager.register(PytestMergify(), name="PytestMergify")
 
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -129,7 +129,6 @@ def test_span_git(
 ) -> None:
     monkeypatch.setenv("GITHUB_ACTIONS", "false")
     git.side_effect = [
-        "https://github.com/Mergifyio/pytest-mergify",
         "main",
         "azerty",
         "https://github.com/Mergifyio/pytest-mergify",


### PR DESCRIPTION
Plugin was registered twice in tests when using `runpytest_inprocess`.
I think it's a good security to make sure that we are creating only one
instance of the plugin for each session.