### PR TITLE
feat(ci-insights): add Buildkite CI provider support

### DIFF
--- a/pytest_mergify/ci_insights.py
+++ b/pytest_mergify/ci_insights.py
@@ -18,6 +18,7 @@ import pytest_mergify.resources.ci as resources_ci
 import pytest_mergify.resources.git as resources_git
 import pytest_mergify.resources.github_actions as resources_gha
 import pytest_mergify.resources.jenkins as resources_jenkins
+import pytest_mergify.resources.buildkite as resources_buildkite
 import pytest_mergify.resources.mergify as resources_mergify
 import pytest_mergify.resources.pytest as resources_pytest
 from pytest_mergify import flaky_detection, utils
@@ -133,6 +134,7 @@ class MergifyCIInsights:
                 resources_ci.CIResourceDetector(),
                 resources_gha.GitHubActionsResourceDetector(),
                 resources_jenkins.JenkinsResourceDetector(),
+                resources_buildkite.BuildkiteResourceDetector(),
                 resources_pytest.PytestResourceDetector(),
                 resources_mergify.MergifyResourceDetector(),
             ]

--- a/pytest_mergify/resources/buildkite.py
+++ b/pytest_mergify/resources/buildkite.py
@@ -1,0 +1,45 @@
+import os
+
+from opentelemetry.sdk.resources import Resource, ResourceDetector
+from opentelemetry.semconv._incubating.attributes import cicd_attributes, vcs_attributes
+
+from pytest_mergify import utils
+from pytest_mergify.resources import git
+
+
+class BuildkiteResourceDetector(ResourceDetector):
+    """Detects OpenTelemetry Resource attributes for Buildkite."""
+
+    OPENTELEMETRY_BUILDKITE_MAPPING = {
+        cicd_attributes.CICD_PIPELINE_NAME: (str, "BUILDKITE_PIPELINE_SLUG"),
+        cicd_attributes.CICD_PIPELINE_TASK_NAME: (
+            str,
+            lambda: os.getenv("BUILDKITE_LABEL") or os.getenv("BUILDKITE_STEP_KEY"),
+        ),
+        cicd_attributes.CICD_PIPELINE_RUN_ID: (str, "BUILDKITE_BUILD_ID"),
+        "cicd.pipeline.run.url": (str, "BUILDKITE_BUILD_URL"),
+        "cicd.pipeline.run.attempt": (
+            int,
+            lambda: int(os.getenv("BUILDKITE_RETRY_COUNT", "0")) + 1,
+        ),
+        "cicd.pipeline.runner.name": (str, "BUILDKITE_AGENT_NAME"),
+        vcs_attributes.VCS_REF_HEAD_NAME: (str, "BUILDKITE_BRANCH"),
+        vcs_attributes.VCS_REF_BASE_NAME: (str, "BUILDKITE_PULL_REQUEST_BASE_BRANCH"),
+        vcs_attributes.VCS_REF_HEAD_REVISION: (str, "BUILDKITE_COMMIT"),
+        vcs_attributes.VCS_REPOSITORY_URL_FULL: (str, "BUILDKITE_REPO"),
+        "vcs.repository.name": (
+            str,
+            lambda: utils.get_repository_name_from_env_url("BUILDKITE_REPO"),
+        ),
+    }
+
+    def detect(self) -> Resource:
+        if utils.get_ci_provider() != "buildkite":
+            return Resource({})
+
+        attributes = utils.get_attributes(
+            git.GitResourceDetector.OPENTELEMETRY_GIT_MAPPING
+        )
+        attributes.update(utils.get_attributes(self.OPENTELEMETRY_BUILDKITE_MAPPING))
+
+        return Resource(attributes)

--- a/pytest_mergify/utils.py
+++ b/pytest_mergify/utils.py
@@ -7,13 +7,14 @@ import subprocess
 import typing
 
 CIProviderT = typing.Literal[
-    "github_actions", "circleci", "pytest_mergify_suite", "jenkins"
+    "github_actions", "circleci", "pytest_mergify_suite", "jenkins", "buildkite"
 ]
 
 SUPPORTED_CIs: typing.Dict[str, CIProviderT] = {
     "GITHUB_ACTIONS": "github_actions",
     "CIRCLECI": "circleci",
     "JENKINS_URL": "jenkins",
+    "BUILDKITE": "buildkite",
     "_PYTEST_MERGIFY_TEST": "pytest_mergify_suite",
 }
 
@@ -117,6 +118,9 @@ def get_repository_name() -> typing.Optional[str]:
 
     if provider == "circleci":
         return get_repository_name_from_env_url("CIRCLE_REPOSITORY_URL")
+
+    if provider == "buildkite":
+        return get_repository_name_from_env_url("BUILDKITE_REPO")
 
     if provider == "pytest_mergify_suite":
         return "Mergifyio/pytest-mergify"


### PR DESCRIPTION
Detect Buildkite environment and extract OpenTelemetry resource
attributes: pipeline name, job name, build ID/URL, retry count,
agent name, branch, base branch, commit SHA, and repository.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>