### PR TITLE
fix(quarantine): Walk paginated /quarantines pages

### DIFF
--- a/pytest_mergify/quarantine.py
+++ b/pytest_mergify/quarantine.py
@@ -27,32 +27,59 @@ class Quarantine:
             self.init_error_msg = f"Repository name '{self.repo_name}' has an unexpected format (expected 'owner/repository'), skipping Mergify Test Insights Quarantine initialization"
             return
 
-        url = f"{self.api_url}/v1/ci/{owner}/repositories/{repository}/quarantines"
+        url: typing.Optional[str] = (
+            f"{self.api_url}/v1/ci/{owner}/repositories/{repository}/quarantines"
+        )
+        # Filters and per_page go on the first request only; for subsequent
+        # pages the URL comes verbatim from the RFC 5988 `next` link and
+        # carries everything the server wants on the next call.
+        params: typing.Optional[typing.Dict[str, typing.Any]] = {
+            "branch": self.branch_name,
+            "per_page": 100,
+        }
+        headers = {"Authorization": f"Bearer {self.token}"}
+        quarantined_tests: typing.List[str] = []
+        # Guard against a buggy server (or stale CI proxy) returning a `next`
+        # link that loops back to a URL we have already fetched.
+        seen_urls: typing.Set[str] = set()
 
-        try:
-            quarantine_resp: requests.Response = requests.get(
-                url,
-                headers={"Authorization": f"Bearer {self.token}"},
-                params={"branch": self.branch_name},
-                timeout=10,
+        while url is not None:
+            if url in seen_urls:
+                self.init_error_msg = "Mergify's API returned a cyclic `next` link, aborting. Tests won't be quarantined."
+                return
+            seen_urls.add(url)
+
+            try:
+                quarantine_resp: requests.Response = requests.get(
+                    url,
+                    headers=headers,
+                    params=params,
+                    timeout=10,
+                )
+            except requests.RequestException as exc:
+                self.init_error_msg = f"Failed to connect to Mergify's API, tests won't be quarantined. Error: {str(exc)}"
+                return
+
+            if quarantine_resp.status_code == 402:
+                # No Mergify Test Insights Quarantine subscription, skip it.
+                return
+
+            try:
+                quarantine_resp.raise_for_status()
+            except requests.HTTPError as exc:
+                self.init_error_msg = f"Error when querying Mergify's API, tests won't be quarantined. Error: {str(exc)}"
+                return
+
+            quarantined_tests.extend(
+                qtest["test_name"]
+                for qtest in quarantine_resp.json()["quarantined_tests"]
             )
-        except requests.RequestException as exc:
-            self.init_error_msg = f"Failed to connect to Mergify's API, tests won't be quarantined. Error: {str(exc)}"
-            return
 
-        if quarantine_resp.status_code == 402:
-            # No Mergify Test Insights Quarantine subscription, skip it.
-            return
+            next_link = quarantine_resp.links.get("next")
+            url = next_link["url"] if next_link else None
+            params = None
 
-        try:
-            quarantine_resp.raise_for_status()
-        except requests.HTTPError as exc:
-            self.init_error_msg = f"Error when querying Mergify's API, tests won't be quarantined. Error: {str(exc)}"
-            return
-
-        self.quarantined_tests = [
-            qtest["test_name"] for qtest in quarantine_resp.json()["quarantined_tests"]
-        ]
+        self.quarantined_tests = quarantined_tests
 
     def __contains__(self, item: _pytest.nodes.Item) -> bool:
         return item.nodeid in self.quarantined_tests

--- a/tests/test_quarantine.py
+++ b/tests/test_quarantine.py
@@ -27,3 +27,136 @@ def test_quarantine_handles_requests_exception(monkeypatch: pytest.MonkeyPatch) 
     assert "Failed to connect to Mergify's API" in q.init_error_msg
     # Should not have populated quarantined tests
     assert q.quarantined_tests == []
+
+
+@responses.activate
+def test_quarantine_walks_paginated_pages() -> None:
+    base_url = "https://example.com/v1/ci/owner/repositories/repo/quarantines"
+    page2_url = f"{base_url}?cursor=PAGE2&per_page=100"
+    page3_url = f"{base_url}?cursor=PAGE3&per_page=100"
+
+    responses.add(
+        responses.GET,
+        base_url,
+        json={"quarantined_tests": [{"test_name": "test_a"}, {"test_name": "test_b"}]},
+        headers={"Link": f'<{page2_url}>; rel="next"'},
+        match=[
+            responses.matchers.query_param_matcher(
+                {"branch": "main", "per_page": "100"}
+            )
+        ],
+    )
+    responses.add(
+        responses.GET,
+        base_url,
+        json={"quarantined_tests": [{"test_name": "test_c"}]},
+        headers={"Link": f'<{page3_url}>; rel="next"'},
+        match=[
+            responses.matchers.query_param_matcher(
+                {"cursor": "PAGE2", "per_page": "100"}
+            )
+        ],
+    )
+    responses.add(
+        responses.GET,
+        base_url,
+        json={"quarantined_tests": [{"test_name": "test_d"}]},
+        match=[
+            responses.matchers.query_param_matcher(
+                {"cursor": "PAGE3", "per_page": "100"}
+            )
+        ],
+    )
+
+    q = Quarantine(
+        api_url="https://example.com",
+        token="tok",
+        repo_name="owner/repo",
+        branch_name="main",
+    )
+
+    assert q.init_error_msg is None
+    assert q.quarantined_tests == ["test_a", "test_b", "test_c", "test_d"]
+
+
+@responses.activate
+def test_quarantine_resets_on_mid_pagination_error() -> None:
+    base_url = "https://example.com/v1/ci/owner/repositories/repo/quarantines"
+    page2_url = f"{base_url}?cursor=PAGE2&per_page=100"
+
+    responses.add(
+        responses.GET,
+        base_url,
+        json={"quarantined_tests": [{"test_name": "test_a"}]},
+        headers={"Link": f'<{page2_url}>; rel="next"'},
+        match=[
+            responses.matchers.query_param_matcher(
+                {"branch": "main", "per_page": "100"}
+            )
+        ],
+    )
+    responses.add(
+        responses.GET,
+        base_url,
+        status=500,
+        match=[
+            responses.matchers.query_param_matcher(
+                {"cursor": "PAGE2", "per_page": "100"}
+            )
+        ],
+    )
+
+    q = Quarantine(
+        api_url="https://example.com",
+        token="tok",
+        repo_name="owner/repo",
+        branch_name="main",
+    )
+
+    assert q.init_error_msg is not None
+    assert "Error when querying Mergify's API" in q.init_error_msg
+    # No partial population: a failure on page 2 must not leak page 1's data.
+    assert q.quarantined_tests == []
+
+
+@responses.activate
+def test_quarantine_aborts_on_pagination_cycle() -> None:
+    base_url = "https://example.com/v1/ci/owner/repositories/repo/quarantines"
+    # `next` link cycles back to a previously fetched URL.
+    cycling_url = f"{base_url}?cursor=LOOP&per_page=100"
+
+    responses.add(
+        responses.GET,
+        base_url,
+        json={"quarantined_tests": [{"test_name": "test_a"}]},
+        headers={"Link": f'<{cycling_url}>; rel="next"'},
+        match=[
+            responses.matchers.query_param_matcher(
+                {"branch": "main", "per_page": "100"}
+            )
+        ],
+    )
+    responses.add(
+        responses.GET,
+        base_url,
+        json={"quarantined_tests": [{"test_name": "test_b"}]},
+        # Page 2 advertises itself as the next link, forming a cycle.
+        headers={"Link": f'<{cycling_url}>; rel="next"'},
+        match=[
+            responses.matchers.query_param_matcher(
+                {"cursor": "LOOP", "per_page": "100"}
+            )
+        ],
+    )
+
+    q = Quarantine(
+        api_url="https://example.com",
+        token="tok",
+        repo_name="owner/repo",
+        branch_name="main",
+    )
+
+    assert q.init_error_msg is not None
+    assert "cyclic" in q.init_error_msg
+    # Cycle detected before assigning to self; no partial data leaks.
+    assert q.quarantined_tests == []


### PR DESCRIPTION
The Mergify API kept the unpaginated `GET /v1/ci/{owner}/repositories/{repo}/quarantines` shortcut for backward compatibility but its OpenAPI now states the shortcut "is expected to go away once all callers paginate." Repositories with large quarantine sets (e.g. PSPDFKit at 2,463 entries) trigger statement timeouts on the unpaginated path. Walking RFC 5988 `next` links bounds each request and lets the server drop the shortcut.

References: MRGFY-7391