### PR TITLE
feat(flaky-detection): Skip flaky detection on draft pull requests

### DIFF
--- a/pytest_mergify/ci_insights.py
+++ b/pytest_mergify/ci_insights.py
@@ -192,6 +192,12 @@ class MergifyCIInsights:
         ):
             return
 
+        # Draft pull requests (e.g. Mergify merge-queue batch PRs) run CI but
+        # must not spend extra CI budget on reruns, so skip flaky detection on
+        # them. Non-draft PRs and push/scheduled runs are unaffected.
+        if utils.is_draft_pull_request():
+            return
+
         try:
             self.flaky_detector = flaky_detection.FlakyDetector(
                 token=self.token,

--- a/pytest_mergify/utils.py
+++ b/pytest_mergify/utils.py
@@ -2,6 +2,7 @@ import dataclasses
 import datetime
 import json
 import os
+import pathlib
 import re
 import subprocess
 import typing
@@ -186,3 +187,38 @@ def is_env_truthy(key: str) -> bool:
         "on",
         "1",
     }
+
+
+def is_draft_pull_request() -> bool:
+    """Returns `True` when the current GitHub Actions run targets a draft pull
+    request (e.g. a Mergify merge-queue batch pull request), `False` otherwise.
+
+    Draft pull requests run CI but must not spend extra CI budget on
+    flaky-detection reruns.
+    """
+    if os.getenv("GITHUB_EVENT_NAME") not in ("pull_request", "pull_request_target"):
+        return False
+
+    event_raw_path = os.getenv("GITHUB_EVENT_PATH")
+    if not event_raw_path:
+        return False
+
+    event_path = pathlib.Path(event_raw_path)
+    if not event_path.is_file():
+        return False
+
+    try:
+        event = json.loads(event_path.read_bytes())
+    except (OSError, ValueError):
+        # A malformed or unreadable event payload must not crash the plugin;
+        # keep flaky detection enabled in that case.
+        return False
+
+    if not isinstance(event, dict):
+        return False
+
+    pull_request = event.get("pull_request")
+    if not isinstance(pull_request, dict):
+        return False
+
+    return bool(pull_request.get("draft", False))

--- a/tests/test_ci_insights.py
+++ b/tests/test_ci_insights.py
@@ -1,4 +1,6 @@
 import datetime
+import json
+import pathlib
 import re
 import typing
 
@@ -24,6 +26,11 @@ def _set_test_environment(
     monkeypatch.setenv("GITHUB_REPOSITORY", "Mergifyio/pytest-mergify")
     monkeypatch.setenv("MERGIFY_API_URL", "https://example.com")
     monkeypatch.setenv("MERGIFY_TOKEN", "my_token")
+
+    # Isolate the ambient GitHub event so the draft-PR gate does not leak into
+    # these tests (e.g. when the suite itself runs on a draft pull request).
+    monkeypatch.delenv("GITHUB_EVENT_NAME", raising=False)
+    monkeypatch.delenv("GITHUB_EVENT_PATH", raising=False)
 
     if mode == "new":
         # Simulate a PR context: `GITHUB_BASE_REF` is only set for PRs and is
@@ -129,6 +136,30 @@ def test_load_flaky_detection_error_without_existing_tests(
         "No existing tests found for 'Mergifyio/pytest-mergify' repository"
         in client.flaky_detector_error_message
     )
+
+
+@responses.activate
+def test_flaky_detection_skipped_on_draft_pull_request(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    _set_test_environment(monkeypatch)
+    _make_quarantine_mock()
+
+    event_file = tmp_path / "event.json"
+    event_file.write_text(
+        json.dumps({"pull_request": {"draft": True, "head": {"sha": "abc123"}}})
+    )
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_file))
+
+    client = _make_test_client()
+
+    # Flaky detection is disabled, so no reruns consume CI budget on draft PRs.
+    assert client.flaky_detector is None
+    assert client.flaky_detector_error_message is None
+    # Other features remain active on draft PRs.
+    assert client.quarantined_tests is not None
 
 
 @responses.activate

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,9 @@
+import json
+import pathlib
+
 import pytest
 
+from pytest_mergify import utils
 from pytest_mergify.utils import get_repository_name_from_url
 
 
@@ -45,3 +49,93 @@ def test_get_repository_name_from_url_invalid(url: str) -> None:
     """Test invalid URL formats that should return None."""
     result = get_repository_name_from_url(url)
     assert result is None
+
+
+def _write_event_file(tmp_path: pathlib.Path, payload: object) -> str:
+    event_file = tmp_path / "event.json"
+    event_file.write_text(json.dumps(payload))
+    return str(event_file)
+
+
+def test_is_draft_pull_request_draft(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv(
+        "GITHUB_EVENT_PATH",
+        _write_event_file(tmp_path, {"pull_request": {"draft": True}}),
+    )
+    assert utils.is_draft_pull_request() is True
+
+
+def test_is_draft_pull_request_not_draft(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv(
+        "GITHUB_EVENT_PATH",
+        _write_event_file(tmp_path, {"pull_request": {"draft": False}}),
+    )
+    assert utils.is_draft_pull_request() is False
+
+
+def test_is_draft_pull_request_not_a_pull_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
+    assert utils.is_draft_pull_request() is False
+
+
+def test_is_draft_pull_request_no_event_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.delenv("GITHUB_EVENT_PATH", raising=False)
+    assert utils.is_draft_pull_request() is False
+
+
+def test_is_draft_pull_request_missing_event_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(tmp_path / "missing.json"))
+    assert utils.is_draft_pull_request() is False
+
+
+def test_is_draft_pull_request_malformed_event_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    event_file = tmp_path / "event.json"
+    event_file.write_text("{ not valid json")
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_file))
+    assert utils.is_draft_pull_request() is False
+
+
+@pytest.mark.parametrize(
+    argnames="payload",
+    argvalues=[
+        pytest.param([], id="Not an object"),
+        pytest.param({}, id="Missing pull request"),
+        pytest.param(
+            {"pull_request": "not-an-object"}, id="Pull request not an object"
+        ),
+    ],
+)
+def test_is_draft_pull_request_unexpected_payload_shape(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path, payload: object
+) -> None:
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", _write_event_file(tmp_path, payload))
+    assert utils.is_draft_pull_request() is False
+
+
+def test_is_draft_pull_request_target_event(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request_target")
+    monkeypatch.setenv(
+        "GITHUB_EVENT_PATH",
+        _write_event_file(tmp_path, {"pull_request": {"draft": True}}),
+    )
+    assert utils.is_draft_pull_request() is True


### PR DESCRIPTION
Mergify merge-queue batch PRs are draft pull requests that still run CI.
Flaky detection reruns each in-scope test many times, so running it on
those drafts spends CI budget on runs we do not gate on. Reserve reruns
for real, open pull requests by reading `pull_request.draft` from the
GitHub Actions event payload and skipping detector setup on drafts.