### PR TITLE
feat(flaky-detection): Add pytest-xdist support to flaky detection system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
     # https://github.com/pytest-dev/pytest-asyncio/issues/706#issuecomment-2082788963
     "pytest-asyncio>=0.24.0",
     "freezegun>=1.5.5",
+    "pytest-xdist>=3.0",
 ]
 
 [build-system]

--- a/pytest_mergify/__init__.py
+++ b/pytest_mergify/__init__.py
@@ -19,6 +19,7 @@ import pytest_timeout
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
+from pytest_mergify import flaky_detection as _flaky_detection
 from pytest_mergify import utils
 from pytest_mergify.ci_insights import MergifyCIInsights
 
@@ -32,6 +33,50 @@ class PytestMergify:
         if api_url is not None:
             kwargs["api_url"] = api_url
         self.mergify_ci = MergifyCIInsights(**kwargs)
+
+        self._xdist_controller = _flaky_detection.XdistFlakyDetectionController()
+
+        if _is_xdist_worker(config):
+            self._load_flaky_detector_from_xdist_worker(config)
+
+    def _load_flaky_detector_from_xdist_worker(
+        self, config: _pytest.config.Config
+    ) -> None:
+        """Load flaky detector from controller-provided context on xdist workers."""
+        workerinput = getattr(config, "workerinput", {})
+        context = workerinput.get("flaky_detection_context")
+        mode = workerinput.get("flaky_detection_mode")
+        if context is not None and mode is not None:
+            self.mergify_ci.load_flaky_detector_from_context(context, mode)
+
+    @pytest.hookimpl(optionalhook=True)
+    def pytest_configure_node(self, node: typing.Any) -> None:
+        """xdist hook: distribute flaky detection context to workers."""
+        # Disable under 'each' mode to avoid duplicated budgets.
+        if getattr(node.config.option, "dist", None) == "each":
+            return
+
+        # Lazily extract context on first node setup to avoid timing issues
+        # with xdist's dsession registration.
+        if not self._xdist_controller.has_context and self.mergify_ci.flaky_detector:
+            self._xdist_controller.extract_context_from_detector(
+                self.mergify_ci.flaky_detector
+            )
+
+        self._xdist_controller.populate_workerinput(node.workerinput)
+
+    @pytest.hookimpl(optionalhook=True)
+    def pytest_testnodedown(self, node: typing.Any, error: typing.Any) -> None:
+        """xdist hook: collect metrics from completed workers."""
+        workeroutput = getattr(node, "workeroutput", None)
+        if workeroutput is None:
+            return
+
+        worker_metrics = workeroutput.get("flaky_detection_metrics")
+        if worker_metrics is None:
+            return
+
+        self._xdist_controller.collect_worker_metrics(worker_metrics)
 
     def pytest_terminal_summary(
         self, terminalreporter: _pytest.terminal.TerminalReporter
@@ -56,19 +101,18 @@ class PytestMergify:
             )
             return
 
-        if self.mergify_ci.flaky_detector:
+        if _is_xdist_controller(terminalreporter.config):
+            if self._xdist_controller.has_context:
+                terminalreporter.write_line(self._xdist_controller.make_report())
+            elif self.mergify_ci.flaky_detector_error_message:
+                _write_flaky_detector_error(
+                    terminalreporter, self.mergify_ci.flaky_detector_error_message
+                )
+        elif self.mergify_ci.flaky_detector:
             terminalreporter.write_line(self.mergify_ci.flaky_detector.make_report())
         elif self.mergify_ci.flaky_detector_error_message:
-            terminalreporter.write_line(
-                f"""⚠️ Flaky detection couldn't be enabled because of an error.
-
-Common issues:
-  • Your 'MERGIFY_TOKEN' might not be set or could be invalid
-  • There might be a network connectivity issue with the Mergify API
-
-📚 Documentation: https://docs.mergify.com/ci-insights/test-frameworks/pytest/
-🔍 Details: {self.mergify_ci.flaky_detector_error_message}""",
-                yellow=True,
+            _write_flaky_detector_error(
+                terminalreporter, self.mergify_ci.flaky_detector_error_message
             )
 
         # Mergify Test Insights Quarantine warning logs
@@ -149,6 +193,14 @@ Common issues:
         self,
         session: _pytest.main.Session,
     ) -> typing.Generator[None, None, None]:
+        # xdist worker: export metrics via workeroutput (independent of tracer).
+        if _is_xdist_worker(session.config) and self.mergify_ci.flaky_detector:
+            workeroutput = getattr(session.config, "workeroutput", None)
+            if workeroutput is not None:
+                workeroutput["flaky_detection_metrics"] = (
+                    self.mergify_ci.flaky_detector.to_serializable_metrics()
+                )
+
         if not self.tracer:
             yield
             return
@@ -200,60 +252,90 @@ Common issues:
         # flow. Returning `True` means we took care of running the protocol.
         # See:
         # https://docs.pytest.org/en/7.1.x/how-to/writing_hook_functions.html#firstresult
-        if not self.tracer:
+        if not self.tracer and not self.mergify_ci.flaky_detector:
             return None
+
+        if self.tracer:
+            return self._run_test_protocol_with_tracing(item, nextitem)
+
+        return self._run_test_protocol(item, nextitem)
+
+    def _run_test_protocol_with_tracing(
+        self,
+        item: _pytest.nodes.Item,
+        nextitem: typing.Optional[_pytest.nodes.Item],
+    ) -> bool:
+        """Run test protocol with tracing and optional flaky detection."""
+        assert self.tracer is not None
 
         with self.tracer.start_as_current_span(
             name=item.nodeid,
             context=opentelemetry.trace.set_span_in_context(self.session_span),
             attributes=self._get_item_attributes(item),
         ) as current_span:
-            distinct_outcomes = set()
-
-            # Execute the initial protocol to register its duration, which lets
-            # us calculate the number of reruns.
-            for report in _pytest.runner.runtestprotocol(
-                item=item, nextitem=nextitem, log=True
-            ):
-                distinct_outcomes.add(report.outcome)
-
-            if (
-                not self.mergify_ci.flaky_detector
-                or not self.mergify_ci.flaky_detector.is_rerunning_test(item.nodeid)
-            ):
-                return True
-
-            self.mergify_ci.flaky_detector.set_test_deadline(
-                test=item.nodeid,
-                timeout=datetime.timedelta(seconds=timeout_seconds)
-                if (timeout_seconds := pytest_timeout._get_item_settings(item).timeout)
-                else None,
+            distinct_outcomes, rerun_count = self._execute_test_with_reruns(
+                item, nextitem
             )
 
-            if self.mergify_ci.flaky_detector.is_test_too_slow(item.nodeid):
-                # We won't be able to detect flakiness if the test is too slow,
-                # so we stop here.
-                return True
-
-            rerun_count = 0
-            while not item.keywords.get("is_last_rerun"):
-                item.keywords["is_last_rerun"] = (
-                    self.mergify_ci.flaky_detector.is_last_rerun_for_test(item.nodeid)
-                )
-
-                # Always execute a last rerun before stopping to properly
-                # restore finalizers. Otherwise, it can lead to resource leaks.
-                for report in self._reruntestprotocol(item, nextitem):
-                    distinct_outcomes.add(report.outcome)
-
-                rerun_count += 1
-
-            if "failed" in distinct_outcomes and "passed" in distinct_outcomes:
-                current_span.set_attribute("cicd.test.flaky", True)
-
-            current_span.set_attribute("cicd.test.rerun_count", rerun_count)
+            if rerun_count > 0:
+                if "failed" in distinct_outcomes and "passed" in distinct_outcomes:
+                    current_span.set_attribute("cicd.test.flaky", True)
+                current_span.set_attribute("cicd.test.rerun_count", rerun_count)
 
         return True
+
+    def _run_test_protocol(
+        self,
+        item: _pytest.nodes.Item,
+        nextitem: typing.Optional[_pytest.nodes.Item],
+    ) -> bool:
+        """Run test protocol without tracing (e.g. xdist workers without tracer)."""
+        self._execute_test_with_reruns(item, nextitem)
+        return True
+
+    def _execute_test_with_reruns(
+        self,
+        item: _pytest.nodes.Item,
+        nextitem: typing.Optional[_pytest.nodes.Item],
+    ) -> typing.Tuple[typing.Set[str], int]:
+        """Run initial test and flaky detection reruns. Returns (outcomes, rerun_count)."""
+        distinct_outcomes: typing.Set[str] = set()
+
+        for report in _pytest.runner.runtestprotocol(
+            item=item, nextitem=nextitem, log=True
+        ):
+            distinct_outcomes.add(report.outcome)
+
+        if (
+            not self.mergify_ci.flaky_detector
+            or not self.mergify_ci.flaky_detector.is_rerunning_test(item.nodeid)
+        ):
+            return distinct_outcomes, 0
+
+        self.mergify_ci.flaky_detector.set_test_deadline(
+            test=item.nodeid,
+            timeout=datetime.timedelta(seconds=timeout_seconds)
+            if (timeout_seconds := pytest_timeout._get_item_settings(item).timeout)
+            else None,
+        )
+
+        if self.mergify_ci.flaky_detector.is_test_too_slow(item.nodeid):
+            return distinct_outcomes, 0
+
+        rerun_count = 0
+        while not item.keywords.get("is_last_rerun"):
+            item.keywords["is_last_rerun"] = (
+                self.mergify_ci.flaky_detector.is_last_rerun_for_test(item.nodeid)
+            )
+
+            # Always execute a last rerun before stopping to properly
+            # restore finalizers. Otherwise, it can lead to resource leaks.
+            for report in self._reruntestprotocol(item, nextitem):
+                distinct_outcomes.add(report.outcome)
+
+            rerun_count += 1
+
+        return distinct_outcomes, rerun_count
 
     def _reruntestprotocol(
         self, item: _pytest.nodes.Item, nextitem: typing.Optional[_pytest.nodes.Item]
@@ -464,3 +546,32 @@ def _should_skip_item(item: _pytest.nodes.Item) -> bool:
 
     # nosemgrep: python.lang.security.audit.eval-detected.eval-detected
     return bool(eval(condition_code, globals_))
+
+
+def _write_flaky_detector_error(
+    terminalreporter: _pytest.terminal.TerminalReporter,
+    error_message: str,
+) -> None:
+    terminalreporter.write_line(
+        f"""⚠️ Flaky detection couldn't be enabled because of an error.
+
+Common issues:
+  • Your 'MERGIFY_TOKEN' might not be set or could be invalid
+  • There might be a network connectivity issue with the Mergify API
+
+📚 Documentation: https://docs.mergify.com/ci-insights/test-frameworks/pytest/
+🔍 Details: {error_message}""",
+        yellow=True,
+    )
+
+
+def _is_xdist_controller(config: _pytest.config.Config) -> bool:
+    """Check if running as xdist controller (not a worker)."""
+    return config.pluginmanager.has_plugin("dsession") and not hasattr(
+        config, "workerinput"
+    )
+
+
+def _is_xdist_worker(config: _pytest.config.Config) -> bool:
+    """Check if running as xdist worker."""
+    return hasattr(config, "workerinput")

--- a/pytest_mergify/ci_insights.py
+++ b/pytest_mergify/ci_insights.py
@@ -189,6 +189,9 @@ class MergifyCIInsights:
             or self.repo_name is None
             # NOTE(remyduthu): Hide behind a feature flag for now.
             or not utils.is_env_truthy("_MERGIFY_TEST_NEW_FLAKY_DETECTION")
+            # On xdist workers the detector is loaded from the controller-
+            # provided context, so skip the redundant per-worker API call.
+            or os.environ.get("PYTEST_XDIST_WORKER") is not None
         ):
             return
 
@@ -197,6 +200,22 @@ class MergifyCIInsights:
                 token=self.token,
                 url=self.api_url,
                 full_repository_name=self.repo_name,
+                mode=mode,
+            )
+        except Exception as exception:
+            self.flaky_detector_error_message = (
+                f"Could not load flaky detector: {str(exception)}"
+            )
+
+    def load_flaky_detector_from_context(
+        self,
+        context_dict: typing.Dict[str, typing.Any],
+        mode: typing.Literal["new", "unhealthy"],
+    ) -> None:
+        """Construct FlakyDetector from pre-fetched context (xdist worker path)."""
+        try:
+            self.flaky_detector = flaky_detection.FlakyDetector.from_context(
+                context_dict=context_dict,
                 mode=mode,
             )
         except Exception as exception:

--- a/pytest_mergify/flaky_detection.py
+++ b/pytest_mergify/flaky_detection.py
@@ -1,5 +1,6 @@
 import dataclasses
 import datetime
+import json
 import os
 import typing
 
@@ -159,8 +160,32 @@ class FlakyDetector:
         init=False, default_factory=list
     )
 
+    _is_xdist: bool = dataclasses.field(init=False, default=False)
+
     def __post_init__(self) -> None:
         self._context = self._fetch_context()
+
+    @classmethod
+    def from_context(
+        cls,
+        context_dict: typing.Dict[str, typing.Any],
+        mode: typing.Literal["new", "unhealthy"],
+    ) -> "FlakyDetector":
+        """Construct from serialized context dict, skipping the API call."""
+        instance = cls.__new__(cls)
+        instance.token = ""
+        instance.url = ""
+        instance.full_repository_name = ""
+        instance.mode = mode
+        instance._context = _FlakyDetectionContext(**context_dict)
+        instance._test_metrics = {}
+        instance._over_length_tests = set()
+        instance._available_budget_duration = datetime.timedelta()
+        instance._tests_to_process = []
+        instance._suspended_item_finalizers = {}
+        instance._debug_logs = []
+        instance._is_xdist = True
+        return instance
 
     def _fetch_context(self) -> _FlakyDetectionContext:
         owner, repository_name = utils.split_full_repo_name(
@@ -287,106 +312,56 @@ class FlakyDetector:
         return will_exceed_deadline or will_exceed_rerun_count
 
     def make_report(self) -> str:
-        result = "🐛 Flaky detection"
-        if self._over_length_tests:
-            result += (
-                f"{os.linesep}- Skipped {len(self._over_length_tests)} "
-                f"test{'s' if len(self._over_length_tests) > 1 else ''}:"
-            )
-            for test in self._over_length_tests:
-                result += (
-                    f"{os.linesep}    • '{test}' has not been tested multiple times because the name of the test "
-                    f"exceeds our limit of {self._context.max_test_name_length} characters"
-                )
-
-        if not self._test_metrics:
-            result += (
-                f"{os.linesep}- No {self.mode} tests detected, but we are watching 👀"
-            )
-
-            return result
-
-        available_budget_duration_seconds = (
-            self._available_budget_duration.total_seconds()
+        """Generate terminal report by delegating to the shared report function."""
+        serialized = self.to_serializable_metrics()
+        return make_report_from_aggregated(
+            context_dict=dataclasses.asdict(self._context),
+            mode=self.mode,
+            available_budget_duration_ms=self._available_budget_duration.total_seconds()
+            * 1000,
+            aggregated_metrics=serialized,
         )
-        used_budget_duration_seconds = self._get_used_budget_duration().total_seconds()
-        result += (
-            f"{os.linesep}- Used {used_budget_duration_seconds / available_budget_duration_seconds * 100:.2f} % of the budget "
-            f"({used_budget_duration_seconds:.2f} s/{available_budget_duration_seconds:.2f} s)"
-        )
-
-        result += (
-            f"{os.linesep}- Active for {len(self._test_metrics)} {self.mode} "
-            f"test{'s' if len(self._test_metrics) > 1 else ''}:"
-        )
-        for test, metrics in self._test_metrics.items():
-            if metrics.rerun_count < self._context.min_test_execution_count:
-                result += (
-                    f"{os.linesep}    • '{test}' is too slow to be tested at least "
-                    f"{self._context.min_test_execution_count} times within the budget"
-                )
-                continue
-
-            rerun_duration_seconds = metrics.total_duration.total_seconds()
-            result += (
-                f"{os.linesep}    • '{test}' has been tested {metrics.rerun_count} "
-                f"time{'s' if metrics.rerun_count > 1 else ''} using approx. "
-                f"{rerun_duration_seconds / available_budget_duration_seconds * 100:.2f} % of the budget "
-                f"({rerun_duration_seconds:.2f} s/{available_budget_duration_seconds:.2f} s)"
-            )
-
-        tests_prevented_from_timeout = [
-            test
-            for test, metrics in self._test_metrics.items()
-            if metrics.prevented_timeout
-        ]
-        if tests_prevented_from_timeout:
-            result += (
-                f"{os.linesep}⚠️ Reduced reruns for the following "
-                f"test{'s' if len(tests_prevented_from_timeout) else ''} to respect 'pytest-timeout':"
-            )
-
-            for test in [
-                test
-                for test, metrics in self._test_metrics.items()
-                if metrics.prevented_timeout
-            ]:
-                result += f"{os.linesep}    • '{test}'"
-
-            result += (
-                f"{os.linesep}To improve flaky detection and prevent fixture-level timeouts from limiting reruns, enable function-only timeouts. "
-                f"Reference: https://github.com/pytest-dev/pytest-timeout?tab=readme-ov-file#avoiding-timeouts-in-fixtures"
-            )
-
-        if os.environ.get("PYTEST_MERGIFY_DEBUG") and self._debug_logs:
-            result += f"{os.linesep}🔎 Debug Logs"
-            for log in self._debug_logs:
-                result += f"{os.linesep}{log.to_json()}"
-
-        return result
 
     def set_test_deadline(
         self, test: str, timeout: typing.Optional[datetime.timedelta] = None
     ) -> None:
         metrics = self._test_metrics[test]
 
-        remaining_budget = self._get_remaining_budget_duration()
-        remaining_tests = self._count_remaining_tests()
-
-        # Distribute remaining budget equally across remaining tests.
-        metrics.deadline = datetime.datetime.now(datetime.timezone.utc) + (
-            remaining_budget / remaining_tests
-        )
-        self._debug_logs.append(
-            utils.StructuredLog.make(
-                message="Deadline set",
-                test=test,
-                available_budget=str(self._available_budget_duration),
-                remaining_budget=str(remaining_budget),
-                all_tests=len(self._tests_to_process),
-                remaining_tests=remaining_tests,
+        if self._is_xdist:
+            # Static allocation: equal share of total budget per test.
+            per_test_budget = self._available_budget_duration / max(
+                len(self._tests_to_process), 1
             )
-        )
+            metrics.deadline = (
+                datetime.datetime.now(datetime.timezone.utc) + per_test_budget
+            )
+            self._debug_logs.append(
+                utils.StructuredLog.make(
+                    message="Deadline set",
+                    test=test,
+                    available_budget=str(self._available_budget_duration),
+                    is_xdist=True,
+                    all_tests=len(self._tests_to_process),
+                )
+            )
+        else:
+            remaining_budget = self._get_remaining_budget_duration()
+            remaining_tests = self._count_remaining_tests()
+
+            # Distribute remaining budget equally across remaining tests.
+            metrics.deadline = datetime.datetime.now(datetime.timezone.utc) + (
+                remaining_budget / remaining_tests
+            )
+            self._debug_logs.append(
+                utils.StructuredLog.make(
+                    message="Deadline set",
+                    test=test,
+                    available_budget=str(self._available_budget_duration),
+                    remaining_budget=str(remaining_budget),
+                    all_tests=len(self._tests_to_process),
+                    remaining_tests=remaining_tests,
+                )
+            )
 
         if not timeout:
             return
@@ -404,7 +379,7 @@ class FlakyDetector:
                     test=test,
                     timeout=str(timeout),
                     safe_timeout=str(safe_timeout),
-                    deadline=metrics.deadline,
+                    deadline=metrics.deadline.isoformat() if metrics.deadline else None,
                 )
             )
 
@@ -438,6 +413,36 @@ class FlakyDetector:
         item.session._setupstate.stack.update(self._suspended_item_finalizers)
         self._suspended_item_finalizers.clear()
 
+    def to_serializable_metrics(self) -> typing.Dict[str, typing.Any]:
+        """Serialize metrics for transport via xdist workeroutput."""
+        return {
+            "available_budget_duration_ms": self._available_budget_duration.total_seconds()
+            * 1000,
+            "test_metrics": {
+                test: {
+                    "rerun_count": metrics.rerun_count,
+                    "total_duration_ms": metrics.total_duration.total_seconds() * 1000,
+                    "initial_setup_duration_ms": metrics.initial_setup_duration.total_seconds()
+                    * 1000,
+                    "initial_call_duration_ms": metrics.initial_call_duration.total_seconds()
+                    * 1000,
+                    "initial_teardown_duration_ms": metrics.initial_teardown_duration.total_seconds()
+                    * 1000,
+                    "prevented_timeout": metrics.prevented_timeout,
+                }
+                for test, metrics in self._test_metrics.items()
+            },
+            "over_length_tests": list(self._over_length_tests),
+            "debug_logs": [
+                {
+                    "timestamp": log.timestamp.isoformat(),
+                    "message": log.message,
+                    **log.attributes,
+                }
+                for log in self._debug_logs
+            ],
+        }
+
     def _count_remaining_tests(self) -> int:
         already_processed_tests = {
             test for test, metrics in self._test_metrics.items() if metrics.deadline
@@ -456,3 +461,161 @@ class FlakyDetector:
             self._available_budget_duration - self._get_used_budget_duration(),
             datetime.timedelta(),
         )
+
+
+@dataclasses.dataclass
+class XdistFlakyDetectionController:
+    """Manages flaky detection state on the xdist controller side."""
+
+    _context_dict: typing.Optional[typing.Dict[str, typing.Any]] = dataclasses.field(
+        default=None
+    )
+    _mode: typing.Optional[str] = dataclasses.field(default=None)
+    _aggregated_metrics: typing.Dict[str, typing.Any] = dataclasses.field(
+        default_factory=lambda: {
+            "test_metrics": {},
+            "over_length_tests": [],
+            "debug_logs": [],
+        }
+    )
+    _available_budget_duration_ms: float = dataclasses.field(default=0.0)
+
+    def extract_context_from_detector(self, detector: FlakyDetector) -> None:
+        """Extract context from an already-loaded detector for distribution."""
+        self._context_dict = dataclasses.asdict(detector._context)
+        self._mode = detector.mode
+
+    @property
+    def has_context(self) -> bool:
+        return self._context_dict is not None
+
+    def populate_workerinput(self, workerinput: typing.Dict[str, typing.Any]) -> None:
+        """Add flaky detection context to a worker's input dict."""
+        if self._context_dict is not None:
+            workerinput["flaky_detection_context"] = self._context_dict
+            workerinput["flaky_detection_mode"] = self._mode
+
+    def collect_worker_metrics(
+        self, worker_metrics: typing.Dict[str, typing.Any]
+    ) -> None:
+        """Merge metrics received from a completed worker."""
+        self._aggregated_metrics["test_metrics"].update(worker_metrics["test_metrics"])
+        self._aggregated_metrics["over_length_tests"].extend(
+            worker_metrics["over_length_tests"]
+        )
+        self._aggregated_metrics["debug_logs"].extend(worker_metrics["debug_logs"])
+
+        # Budget is the same across all workers (deterministic). Use first received.
+        if (
+            self._available_budget_duration_ms == 0.0
+            and "available_budget_duration_ms" in worker_metrics
+        ):
+            self._available_budget_duration_ms = worker_metrics[
+                "available_budget_duration_ms"
+            ]
+
+    def make_report(self) -> str:
+        """Generate terminal report from aggregated worker data."""
+        assert self._context_dict is not None
+        mode: typing.Literal["new", "unhealthy"] = (
+            self._mode  # type: ignore[assignment]
+            if self._mode in ("new", "unhealthy")
+            else "new"
+        )
+        return make_report_from_aggregated(
+            context_dict=self._context_dict,
+            mode=mode,
+            available_budget_duration_ms=self._available_budget_duration_ms,
+            aggregated_metrics=self._aggregated_metrics,
+        )
+
+
+def make_report_from_aggregated(
+    context_dict: typing.Dict[str, typing.Any],
+    mode: typing.Literal["new", "unhealthy"],
+    available_budget_duration_ms: float,
+    aggregated_metrics: typing.Dict[str, typing.Any],
+) -> str:
+    """Generate report on the controller from aggregated worker metrics."""
+    context = _FlakyDetectionContext(**context_dict)
+    test_metrics = aggregated_metrics["test_metrics"]
+    over_length_tests = aggregated_metrics["over_length_tests"]
+    debug_logs = aggregated_metrics["debug_logs"]
+
+    result = "🐛 Flaky detection"
+
+    if over_length_tests:
+        result += (
+            f"{os.linesep}- Skipped {len(over_length_tests)} "
+            f"test{'s' if len(over_length_tests) > 1 else ''}:"
+        )
+        for test in sorted(over_length_tests):
+            result += (
+                f"{os.linesep}    • '{test}' has not been tested multiple times because the name of the test "
+                f"exceeds our limit of {context.max_test_name_length} characters"
+            )
+
+    if not test_metrics:
+        result += f"{os.linesep}- No {mode} tests detected, but we are watching 👀"
+        return result
+
+    available_budget_seconds = available_budget_duration_ms / 1000
+    used_budget_ms = sum(m["total_duration_ms"] for m in test_metrics.values())
+    used_budget_seconds = used_budget_ms / 1000
+    if available_budget_seconds > 0:
+        result += (
+            f"{os.linesep}- Used {used_budget_seconds / available_budget_seconds * 100:.2f} % of the budget "
+            f"({used_budget_seconds:.2f} s/{available_budget_seconds:.2f} s)"
+        )
+    else:
+        result += f"{os.linesep}- Used {used_budget_seconds:.2f} s (budget unavailable)"
+
+    result += (
+        f"{os.linesep}- Active for {len(test_metrics)} {mode} "
+        f"test{'s' if len(test_metrics) > 1 else ''}:"
+    )
+    for test, m in sorted(test_metrics.items()):
+        if m["rerun_count"] < context.min_test_execution_count:
+            result += (
+                f"{os.linesep}    • '{test}' is too slow to be tested at least "
+                f"{context.min_test_execution_count} times within the budget"
+            )
+            continue
+
+        rerun_duration_seconds = m["total_duration_ms"] / 1000
+        if available_budget_seconds > 0:
+            result += (
+                f"{os.linesep}    • '{test}' has been tested {m['rerun_count']} "
+                f"time{'s' if m['rerun_count'] > 1 else ''} using approx. "
+                f"{rerun_duration_seconds / available_budget_seconds * 100:.2f} % of the budget "
+                f"({rerun_duration_seconds:.2f} s/{available_budget_seconds:.2f} s)"
+            )
+        else:
+            result += (
+                f"{os.linesep}    • '{test}' has been tested {m['rerun_count']} "
+                f"time{'s' if m['rerun_count'] > 1 else ''} "
+                f"({rerun_duration_seconds:.2f} s)"
+            )
+
+    tests_prevented_from_timeout = sorted(
+        test for test, m in test_metrics.items() if m["prevented_timeout"]
+    )
+    if tests_prevented_from_timeout:
+        result += (
+            f"{os.linesep}⚠️ Reduced reruns for the following "
+            f"test{'s' if len(tests_prevented_from_timeout) > 1 else ''} to respect 'pytest-timeout':"
+        )
+        for test in tests_prevented_from_timeout:
+            result += f"{os.linesep}    • '{test}'"
+
+        result += (
+            f"{os.linesep}To improve flaky detection and prevent fixture-level timeouts from limiting reruns, enable function-only timeouts. "
+            f"Reference: https://github.com/pytest-dev/pytest-timeout?tab=readme-ov-file#avoiding-timeouts-in-fixtures"
+        )
+
+    if os.environ.get("PYTEST_MERGIFY_DEBUG") and debug_logs:
+        result += f"{os.linesep}🔎 Debug Logs"
+        for log in debug_logs:
+            result += f"{os.linesep}{json.dumps(log)}"
+
+    return result

--- a/tests/test_flaky_detection.py
+++ b/tests/test_flaky_detection.py
@@ -8,6 +8,7 @@ import pytest
 
 import pytest_mergify
 from pytest_mergify import flaky_detection
+from pytest_mergify import utils
 
 _NOW = datetime.datetime(
     year=2025,
@@ -27,6 +28,12 @@ class InitializedFlakyDetector(flaky_detection.FlakyDetector):
         self.full_repository_name = ""
         self.mode = "new"
         self._test_metrics = {}
+        self._over_length_tests = set()
+        self._available_budget_duration = datetime.timedelta()
+        self._tests_to_process = []
+        self._suspended_item_finalizers = {}
+        self._debug_logs = []
+        self._is_xdist = False
 
     def __post_init__(self) -> None:
         pass
@@ -193,3 +200,149 @@ def test_flaky_detector_get_remaining_budget_duration(
     detector._available_budget_duration = available_budget_duration
     detector._test_metrics = test_metrics
     assert expected == detector._get_remaining_budget_duration()
+
+
+def test_flaky_detector_to_serializable_metrics() -> None:
+    detector = InitializedFlakyDetector()
+    detector._context = _make_flaky_detection_context(max_test_name_length=100)
+    detector._test_metrics = {
+        "test_foo": flaky_detection._TestMetrics(
+            initial_setup_duration=datetime.timedelta(milliseconds=100),
+            initial_call_duration=datetime.timedelta(milliseconds=200),
+            initial_teardown_duration=datetime.timedelta(milliseconds=50),
+            rerun_count=3,
+            prevented_timeout=True,
+            total_duration=datetime.timedelta(milliseconds=1050),
+        ),
+    }
+    detector._over_length_tests = {"test_long_name"}
+    detector._debug_logs = [
+        utils.StructuredLog.make(message="test log", key="value"),
+    ]
+
+    result = detector.to_serializable_metrics()
+
+    assert result["test_metrics"]["test_foo"]["rerun_count"] == 3
+    assert result["test_metrics"]["test_foo"]["total_duration_ms"] == 1050.0
+    assert result["test_metrics"]["test_foo"]["initial_setup_duration_ms"] == 100.0
+    assert result["test_metrics"]["test_foo"]["initial_call_duration_ms"] == 200.0
+    assert result["test_metrics"]["test_foo"]["initial_teardown_duration_ms"] == 50.0
+    assert result["test_metrics"]["test_foo"]["prevented_timeout"] is True
+    assert result["over_length_tests"] == ["test_long_name"]
+    assert len(result["debug_logs"]) == 1
+    assert result["debug_logs"][0]["message"] == "test log"
+
+
+def test_flaky_detector_from_context() -> None:
+    context_dict = {
+        "budget_ratio_for_new_tests": 0.1,
+        "budget_ratio_for_unhealthy_tests": 0.05,
+        "existing_test_names": ["test_foo", "test_bar"],
+        "existing_tests_mean_duration_ms": 5000,
+        "unhealthy_test_names": ["test_foo"],
+        "max_test_execution_count": 100,
+        "max_test_name_length": 65536,
+        "min_budget_duration_ms": 4000,
+        "min_test_execution_count": 5,
+    }
+
+    detector = flaky_detection.FlakyDetector.from_context(
+        context_dict=context_dict,
+        mode="new",
+    )
+
+    assert detector.mode == "new"
+    assert detector._context.existing_test_names == ["test_foo", "test_bar"]
+    assert detector._context.existing_tests_mean_duration_ms == 5000
+    assert detector._context.max_test_execution_count == 100
+    assert detector._test_metrics == {}
+    assert detector._tests_to_process == []
+
+
+def test_make_report_from_aggregated() -> None:
+    context_dict = {
+        "budget_ratio_for_new_tests": 0.1,
+        "budget_ratio_for_unhealthy_tests": 0.05,
+        "existing_test_names": ["test_existing"],
+        "existing_tests_mean_duration_ms": 10000,
+        "unhealthy_test_names": [],
+        "max_test_execution_count": 1000,
+        "max_test_name_length": 65536,
+        "min_budget_duration_ms": 4000,
+        "min_test_execution_count": 5,
+    }
+    metrics = {
+        "test_metrics": {
+            "test_bar": {
+                "rerun_count": 10,
+                "total_duration_ms": 1000.0,
+                "initial_setup_duration_ms": 10.0,
+                "initial_call_duration_ms": 80.0,
+                "initial_teardown_duration_ms": 10.0,
+                "prevented_timeout": False,
+            },
+        },
+        "over_length_tests": [],
+        "debug_logs": [],
+    }
+
+    report = flaky_detection.make_report_from_aggregated(
+        context_dict=context_dict,
+        mode="new",
+        available_budget_duration_ms=4000.0,
+        aggregated_metrics=metrics,
+    )
+
+    assert "Flaky detection" in report
+    assert "test_bar" in report
+    assert "has been tested 10 time" in report
+    assert "Active for 1 new test" in report
+
+
+@freezegun.freeze_time(time_to_freeze=_NOW)
+def test_flaky_detector_set_test_deadline_static() -> None:
+    """Under xdist, deadlines use static per-test budget allocation."""
+    detector = InitializedFlakyDetector()
+    detector.mode = "new"
+    detector._is_xdist = True
+    detector._context = _make_flaky_detection_context()
+    detector._available_budget_duration = datetime.timedelta(seconds=10)
+    detector._tests_to_process = ["foo", "bar"]
+    detector._test_metrics = {
+        "foo": flaky_detection._TestMetrics(),
+    }
+
+    detector.set_test_deadline(test="foo")
+
+    metrics = detector._test_metrics["foo"]
+    assert metrics.deadline is not None
+    # Static: 10s / 2 tests = 5s per test.
+    expected_deadline = _NOW + datetime.timedelta(seconds=5)
+    assert metrics.deadline == expected_deadline
+
+
+def test_make_report_from_aggregated_no_tests() -> None:
+    context_dict = {
+        "budget_ratio_for_new_tests": 0.1,
+        "budget_ratio_for_unhealthy_tests": 0.05,
+        "existing_test_names": ["test_existing"],
+        "existing_tests_mean_duration_ms": 10000,
+        "unhealthy_test_names": [],
+        "max_test_execution_count": 1000,
+        "max_test_name_length": 65536,
+        "min_budget_duration_ms": 4000,
+        "min_test_execution_count": 5,
+    }
+
+    report = flaky_detection.make_report_from_aggregated(
+        context_dict=context_dict,
+        mode="new",
+        available_budget_duration_ms=4000.0,
+        aggregated_metrics={
+            "test_metrics": {},
+            "over_length_tests": [],
+            "debug_logs": [],
+        },
+    )
+
+    assert "No new tests detected" in report

--- a/tests/test_xdist.py
+++ b/tests/test_xdist.py
@@ -1,0 +1,300 @@
+import datetime
+import json
+import typing
+
+import _pytest.pytester
+import pytest
+import responses
+
+import pytest_mergify
+from pytest_mergify import ci_insights, flaky_detection, utils
+from tests.test_ci_insights import (
+    _make_flaky_detection_context_mock,
+    _make_quarantine_mock,
+    _set_test_environment,
+)
+
+
+pytest_plugins = ["pytester"]
+
+
+@responses.activate
+def test_flaky_detection_new_tests_end_to_end(
+    monkeypatch: pytest.MonkeyPatch,
+    pytester: _pytest.pytester.Pytester,
+) -> None:
+    """Flaky detection detects new tests end-to-end (non-xdist, validates shared report path)."""
+    _set_test_environment(monkeypatch)
+    _make_quarantine_mock()
+    _make_flaky_detection_context_mock(
+        existing_test_names=[
+            "test_flaky_detection_new_tests_end_to_end.py::test_existing",
+        ],
+    )
+
+    pytester.makepyfile(
+        """
+        def test_existing():
+            assert True
+
+        def test_new_a():
+            assert True
+
+        def test_new_b():
+            assert True
+        """
+    )
+
+    result = pytester.runpytest_inprocess(
+        plugins=[pytest_mergify.PytestMergify()],
+    )
+
+    # Verify flaky detection report is present.
+    result.stdout.fnmatch_lines(["*Flaky detection*"])
+    result.stdout.fnmatch_lines(["*Active for 2 new test*"])
+    result.stdout.fnmatch_lines(["*test_new_a*has been tested*"])
+    result.stdout.fnmatch_lines(["*test_new_b*has been tested*"])
+
+
+def test_xdist_worker_flow_from_context_to_metrics() -> None:
+    """Simulate the full xdist worker lifecycle: context -> prepare -> serialize."""
+    context_dict: typing.Dict[str, typing.Any] = {
+        "budget_ratio_for_new_tests": 0.1,
+        "budget_ratio_for_unhealthy_tests": 0.05,
+        "existing_test_names": ["test_existing"],
+        "existing_tests_mean_duration_ms": 10000,
+        "unhealthy_test_names": [],
+        "max_test_execution_count": 1000,
+        "max_test_name_length": 65536,
+        "min_budget_duration_ms": 4000,
+        "min_test_execution_count": 5,
+    }
+
+    detector = flaky_detection.FlakyDetector.from_context(
+        context_dict=context_dict,
+        mode="new",
+    )
+
+    assert detector._is_xdist is True
+
+    # Simulate serialization round-trip.
+    metrics = detector.to_serializable_metrics()
+    assert isinstance(metrics, dict)
+    assert "test_metrics" in metrics
+    assert "over_length_tests" in metrics
+    assert "debug_logs" in metrics
+
+
+def test_xdist_aggregated_report() -> None:
+    """Controller generates correct report from aggregated worker metrics."""
+    context_dict: typing.Dict[str, typing.Any] = {
+        "budget_ratio_for_new_tests": 0.1,
+        "budget_ratio_for_unhealthy_tests": 0.05,
+        "existing_test_names": ["test_existing"],
+        "existing_tests_mean_duration_ms": 10000,
+        "unhealthy_test_names": [],
+        "max_test_execution_count": 1000,
+        "max_test_name_length": 65536,
+        "min_budget_duration_ms": 4000,
+        "min_test_execution_count": 5,
+    }
+
+    # Simulate metrics from two workers.
+    worker1_metrics: typing.Dict[str, typing.Any] = {
+        "test_new_a": {
+            "rerun_count": 10,
+            "total_duration_ms": 500.0,
+            "initial_setup_duration_ms": 5.0,
+            "initial_call_duration_ms": 40.0,
+            "initial_teardown_duration_ms": 5.0,
+            "prevented_timeout": False,
+        },
+    }
+    worker2_metrics: typing.Dict[str, typing.Any] = {
+        "test_new_b": {
+            "rerun_count": 8,
+            "total_duration_ms": 400.0,
+            "initial_setup_duration_ms": 5.0,
+            "initial_call_duration_ms": 45.0,
+            "initial_teardown_duration_ms": 5.0,
+            "prevented_timeout": False,
+        },
+    }
+
+    aggregated: typing.Dict[str, typing.Any] = {
+        "test_metrics": {**worker1_metrics, **worker2_metrics},
+        "over_length_tests": [],
+        "debug_logs": [],
+    }
+
+    report = flaky_detection.make_report_from_aggregated(
+        context_dict=context_dict,
+        mode="new",
+        available_budget_duration_ms=4000.0,
+        aggregated_metrics=aggregated,
+    )
+
+    assert "Flaky detection" in report
+    assert "test_new_a" in report
+    assert "test_new_b" in report
+    assert "Active for 2 new test" in report
+
+
+@responses.activate
+def test_no_crash_without_xdist(
+    monkeypatch: pytest.MonkeyPatch,
+    pytester: _pytest.pytester.Pytester,
+) -> None:
+    """Plugin works normally without xdist."""
+    _set_test_environment(monkeypatch)
+    _make_quarantine_mock()
+    _make_flaky_detection_context_mock(
+        existing_test_names=["test_no_crash_without_xdist.py::test_pass"],
+    )
+
+    pytester.makepyfile(
+        """
+        def test_pass():
+            assert True
+        """
+    )
+
+    result = pytester.runpytest_inprocess(
+        plugins=[pytest_mergify.PytestMergify()],
+    )
+    result.assert_outcomes(passed=1)
+
+
+def test_flaky_detection_disabled_under_each_mode() -> None:
+    """Controller does not distribute flaky context under 'each' scheduling."""
+    plugin = pytest_mergify.PytestMergify()
+    plugin._xdist_controller = flaky_detection.XdistFlakyDetectionController(
+        _context_dict={"existing_test_names": ["test_a"]},
+        _mode="new",
+    )
+
+    # Mock node with 'each' dist mode.
+    class FakeOption:
+        dist = "each"
+
+    class FakeConfig:
+        option = FakeOption()
+
+    class FakeNode:
+        config = FakeConfig()
+        workerinput: typing.Dict[str, typing.Any] = {}
+
+    node = FakeNode()
+    plugin.pytest_configure_node(node)
+
+    # Context should NOT be distributed.
+    assert "flaky_detection_context" not in node.workerinput
+
+
+def test_flaky_detection_enabled_under_load_mode() -> None:
+    """Controller distributes flaky context under 'load' scheduling."""
+    plugin = pytest_mergify.PytestMergify()
+    plugin._xdist_controller = flaky_detection.XdistFlakyDetectionController(
+        _context_dict={"existing_test_names": ["test_a"]},
+        _mode="new",
+    )
+
+    class FakeOption:
+        dist = "load"
+
+    class FakeConfig:
+        option = FakeOption()
+
+    class FakeNode:
+        config = FakeConfig()
+        workerinput: typing.Dict[str, typing.Any] = {}
+
+    node = FakeNode()
+    plugin.pytest_configure_node(node)
+
+    # Context should be distributed.
+    assert "flaky_detection_context" in node.workerinput
+    assert node.workerinput["flaky_detection_mode"] == "new"
+
+
+def test_plugin_loads_without_xdist(
+    pytester: _pytest.pytester.Pytester,
+) -> None:
+    """The plugin must not crash when pytest-xdist is unavailable.
+
+    The xdist-only hooks must be declared optional; otherwise pluggy rejects
+    them as unknown hooks and aborts every session with an INTERNALERROR.
+    """
+    pytester.makepyfile(
+        """
+        def test_ok():
+            assert True
+        """
+    )
+
+    result = pytester.runpytest_subprocess("-p", "no:xdist")
+
+    result.assert_outcomes(passed=1)
+    assert "INTERNALERROR" not in result.stdout.str()
+
+
+def test_serialized_metrics_stay_serializable_after_timeout_prevention() -> None:
+    """Metrics shipped over xdist IPC must contain only serializable primitives.
+
+    The timeout-prevention path records a deadline in the debug log; keeping it
+    as a raw datetime crashes execnet when a worker ships its metrics home.
+    """
+    detector = flaky_detection.FlakyDetector.from_context(
+        context_dict={
+            "budget_ratio_for_new_tests": 0.1,
+            "budget_ratio_for_unhealthy_tests": 0.05,
+            "existing_test_names": ["test_existing"],
+            "existing_tests_mean_duration_ms": 10000,
+            "unhealthy_test_names": [],
+            "max_test_execution_count": 1000,
+            "max_test_name_length": 65536,
+            "min_budget_duration_ms": 4000,
+            "min_test_execution_count": 5,
+        },
+        mode="new",
+    )
+
+    test = "test_slow"
+    detector._tests_to_process = [test]
+    detector._test_metrics[test] = flaky_detection._TestMetrics()
+    detector._available_budget_duration = datetime.timedelta(seconds=100)
+
+    # A tight timeout forces the timeout-prevention branch, which records the
+    # deadline in a debug log.
+    detector.set_test_deadline(test=test, timeout=datetime.timedelta(seconds=1))
+    assert detector._test_metrics[test].prevented_timeout is True
+
+    # execnet ships this payload verbatim, so it must round-trip through JSON.
+    json.dumps(detector.to_serializable_metrics())
+
+
+@responses.activate
+def test_worker_does_not_fetch_flaky_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """xdist workers load flaky context from the controller, not the API.
+
+    A per-worker fetch would be redundant and multiply API load by the worker
+    count, so the fetch must be skipped when running as a worker.
+    """
+    monkeypatch.setattr(utils, "is_in_ci", lambda: False)
+    monkeypatch.setenv("_MERGIFY_TEST_NEW_FLAKY_DETECTION", "true")
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw0")
+
+    insights = ci_insights.MergifyCIInsights(
+        token="my_token",
+        repo_name="Mergifyio/pytest-mergify",
+        api_url="https://example.com",
+    )
+    insights._load_flaky_detector(mode="new")
+
+    # No HTTP call must be attempted at all; the fetch failing and being
+    # swallowed would still count as the redundant load we want to avoid.
+    assert len(responses.calls) == 0
+    assert insights.flaky_detector is None
+    assert insights.flaky_detector_error_message is None

--- a/uv.lock
+++ b/uv.lock
@@ -151,6 +151,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "freezegun"
 version = "1.5.5"
 source = { registry = "https://pypi.org/simple" }
@@ -455,6 +464,8 @@ dev = [
     { name = "mypy" },
     { name = "poethepoet" },
     { name = "pytest-asyncio" },
+    { name = "pytest-xdist", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest-xdist", version = "3.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "responses" },
     { name = "ruff" },
     { name = "yamllint" },
@@ -477,6 +488,7 @@ dev = [
     { name = "mypy", specifier = ">=1.13.0" },
     { name = "poethepoet", specifier = ">=0.30.0" },
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
+    { name = "pytest-xdist", specifier = ">=3.0" },
     { name = "responses", specifier = ">=0.25.8" },
     { name = "ruff", specifier = ">=0.14.9" },
     { name = "yamllint", specifier = ">=1.35.1" },
@@ -492,6 +504,38 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+dependencies = [
+    { name = "execnet", marker = "python_full_version < '3.9'" },
+    { name = "pytest", marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/c4/3c310a19bc1f1e9ef50075582652673ef2bfc8cd62afef9585683821902f/pytest_xdist-3.6.1.tar.gz", hash = "sha256:ead156a4db231eec769737f57668ef58a2084a34b2e55c4a8fa20d861107300d", size = 84060, upload-time = "2024-04-28T19:29:54.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/82/1d96bf03ee4c0fdc3c0cbe61470070e659ca78dc0086fb88b66c185e2449/pytest_xdist-3.6.1-py3-none-any.whl", hash = "sha256:9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7", size = 46108, upload-time = "2024-04-28T19:29:52.813Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.9'",
+]
+dependencies = [
+    { name = "execnet", marker = "python_full_version >= '3.9'" },
+    { name = "pytest", marker = "python_full_version >= '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add full flaky detection support under pytest-xdist using controller-
orchestrated pre-computed deadlines and xdist's built-in IPC.

Architecture:
- Controller fetches flaky detection context from API once, distributes
  it to workers via workerinput
- Each worker constructs a FlakyDetector from the serialized context,
  computes the same global budget, runs tests with reruns
- Workers send metrics back via workeroutput
- Controller aggregates metrics and generates the terminal report

Changes:
- Add FlakyDetector.from_context() classmethod for worker-side construction
- Add to_serializable_metrics() for xdist IPC (plain builtins only)
- Add make_report_from_aggregated() for controller-side reporting
- Add static deadline mode (_is_xdist flag) preserving dynamic for non-xdist
- Add MergifyCIInsights.load_flaky_detector_from_context()
- Add controller hooks (pytest_configure_node, pytest_testnodedown)
- Add worker hooks (workerinput loading, workeroutput export)
- Disable flaky detection under 'each' scheduling mode
- Add pytest-xdist dev dependency and integration tests

Fixes: MRGFY-6296

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>