### PR TITLE
ci(dependabot): Quote schedule time to pass config validation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,9 @@ updates:
     directory: /
     schedule:
       interval: daily
-      time: 09:00
+      # Dependabot reads a bare 09:00 as a YAML 1.1 sexagesimal integer and
+      # rejects it; the quotes force a string (yamllint 1.2 deems them redundant).
+      time: "09:00"  # yamllint disable-line rule:quoted-strings
       timezone: Europe/Paris
     open-pull-requests-limit: 10
     cooldown:
@@ -13,7 +15,7 @@ updates:
     directory: /
     schedule:
       interval: daily
-      time: 09:00
+      time: "09:00"  # yamllint disable-line rule:quoted-strings
       timezone: Europe/Paris
     cooldown:
       default-days: 7


### PR DESCRIPTION
YAML parses a bare 09:00 as a sexagesimal integer (540), but Dependabot's
schema requires schedule.time to be a string, so its config check fails on
every pull request. Quote both values and silence yamllint's redundant-quote
rule, which reads them as YAML 1.2 (already a string).