### PR TITLE
feat(flaky-detection): Replace private flag with server-driven opt-in

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,9 +25,7 @@ jobs:
           enable-cache: true
           version-file: requirements-uv.txt
 
-      - env:
-          _MERGIFY_TEST_NEW_FLAKY_DETECTION: "true"
-        run: |
+      - run: |
           export UV_PYTHON=${{ matrix.python-version }}
           export UV_LOCKED=1
           uv run poe linters

--- a/poe.toml
+++ b/poe.toml
@@ -3,8 +3,6 @@ type = "uv"
 
 [tool.poe.tasks.test]
 cmd = "pytest -v --pyargs tests"
-[tool.poe.tasks.test.env]
-_MERGIFY_TEST_NEW_FLAKY_DETECTION = "true"
 
 [tool.poe.tasks.linters]
 help = "Run linters"

--- a/pytest_mergify/ci_insights.py
+++ b/pytest_mergify/ci_insights.py
@@ -187,8 +187,6 @@ class MergifyCIInsights:
         if (
             self.token is None
             or self.repo_name is None
-            # NOTE(remyduthu): Hide behind a feature flag for now.
-            or not utils.is_env_truthy("_MERGIFY_TEST_NEW_FLAKY_DETECTION")
             # On xdist workers the detector is loaded from the controller-
             # provided context, so skip the redundant per-worker API call.
             or os.environ.get("PYTEST_XDIST_WORKER") is not None
@@ -202,6 +200,10 @@ class MergifyCIInsights:
                 full_repository_name=self.repo_name,
                 mode=mode,
             )
+        except flaky_detection.FlakyDetectionDisabledError:
+            # The repository has not opted into flaky detection, or has no
+            # baseline yet. Both are expected; skip without an error.
+            return
         except Exception as exception:
             self.flaky_detector_error_message = (
                 f"Could not load flaky detector: {str(exception)}"

--- a/pytest_mergify/flaky_detection.py
+++ b/pytest_mergify/flaky_detection.py
@@ -13,6 +13,15 @@ import requests
 from pytest_mergify import utils
 
 
+class FlakyDetectionDisabledError(Exception):
+    """Flaky detection must not run for this session, and that is expected.
+
+    Raised when the repository has not opted into flaky detection (the server
+    responds with 404) or when there is no baseline of existing tests to
+    compare against yet. Callers skip silently instead of surfacing an error.
+    """
+
+
 @dataclasses.dataclass
 class _FlakyDetectionContext:
     budget_ratio_for_new_tests: float
@@ -198,13 +207,19 @@ class FlakyDetector:
             timeout=10,
         )
 
+        # A 404 means the repository has not opted into flaky detection. This
+        # is the expected default, not an error.
+        if response.status_code == 404:
+            raise FlakyDetectionDisabledError
+
         response.raise_for_status()
 
         result = _FlakyDetectionContext(**response.json())
+
+        # Without a baseline, `new` mode would treat every test as new and
+        # rerun the whole suite. Skip instead of surfacing an error.
         if self.mode == "new" and len(result.existing_test_names) == 0:
-            raise RuntimeError(
-                f"No existing tests found for '{self.full_repository_name}' repository",
-            )
+            raise FlakyDetectionDisabledError
 
         return result
 

--- a/tests/test_ci_insights.py
+++ b/tests/test_ci_insights.py
@@ -17,7 +17,6 @@ def _set_test_environment(
     monkeypatch: pytest.MonkeyPatch,
     mode: typing.Literal["new", "unhealthy"] = "new",
 ) -> None:
-    monkeypatch.setenv("_MERGIFY_TEST_NEW_FLAKY_DETECTION", "true")
     monkeypatch.setenv("_PYTEST_MERGIFY_TEST", "true")
     monkeypatch.setenv("CI", "true")
     monkeypatch.setenv("GITHUB_ACTIONS", "true")
@@ -114,9 +113,27 @@ def test_load_flaky_detection_error(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @responses.activate
-def test_load_flaky_detection_error_without_existing_tests(
+def test_load_flaky_detection_disabled_when_not_opted_in(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """A 404 means the repository has not opted into flaky detection; the
+    client skips silently rather than surfacing an error."""
+    _set_test_environment(monkeypatch)
+
+    _make_quarantine_mock()
+    _make_flaky_detection_context_mock(status=404)
+
+    client = _make_test_client()
+    assert client.flaky_detector is None
+    assert client.flaky_detector_error_message is None
+
+
+@responses.activate
+def test_load_flaky_detection_skipped_without_existing_tests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no baseline in `new` mode, every test would look new and the whole
+    suite would be rerun; the client skips silently rather than erroring."""
     _set_test_environment(monkeypatch)
 
     _make_quarantine_mock()
@@ -124,11 +141,7 @@ def test_load_flaky_detection_error_without_existing_tests(
 
     client = _make_test_client()
     assert client.flaky_detector is None
-    assert client.flaky_detector_error_message is not None
-    assert (
-        "No existing tests found for 'Mergifyio/pytest-mergify' repository"
-        in client.flaky_detector_error_message
-    )
+    assert client.flaky_detector_error_message is None
 
 
 @responses.activate

--- a/tests/test_xdist.py
+++ b/tests/test_xdist.py
@@ -283,7 +283,6 @@ def test_worker_does_not_fetch_flaky_context(
     count, so the fetch must be skipped when running as a worker.
     """
     monkeypatch.setattr(utils, "is_in_ci", lambda: False)
-    monkeypatch.setenv("_MERGIFY_TEST_NEW_FLAKY_DETECTION", "true")
     monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw0")
 
     insights = ci_insights.MergifyCIInsights(


### PR DESCRIPTION
## What

Client-side flaky detection was fully implemented but hard-gated behind the
private, undocumented `_MERGIFY_TEST_NEW_FLAKY_DETECTION` env var, so customers
could never enable it. This removes the gate and makes the feature **opt-in per
repository, decided by the server**.

The client now always requests the flaky-detection context and reacts to the
status:

| Server response | Client behavior |
|---|---|
| `200` + context (baseline may be empty) | Opted in → run detection |
| `404` | Not opted in → **skip silently** |
| `401` / `403` / `5xx` | Real error → surface the warning banner |

The pre-existing empty-baseline guard (new mode with no recorded tests) now also
skips silently instead of raising a spurious error banner — it still prevents
rerunning the whole suite.

xdist is unaffected by design: only the controller fetches the context, so a
`404` leaves it with no context to distribute and the workers skip too.

## Why

`_MERGIFY_TEST_NEW_FLAKY_DETECTION` was private and undocumented — no customer
could discover or set it (zero customer adoption confirmed via prod APM).
Moving the decision server-side lets customers enable flaky detection from the
dashboard.

## ⚠️ Rollout dependency

**Do not release to customers until the server returns `404` for repositories
that have not opted in.** Until then, a not-opted-in repo could receive budgets
and start rerunning tests. The server change is being implemented in parallel;
rollout is coordinated in MRGFY-7580.

## Also

- Drops the defunct flag from the test environment, `poe.toml`, and CI.

## Test plan

- `poe linters` (ruff + mypy strict + yamllint) ✓
- `poe test` — 96 passed ✓
- New tests: `test_load_flaky_detection_disabled_when_not_opted_in` (404 →
  silent), `test_load_flaky_detection_skipped_without_existing_tests` (empty
  baseline → silent)

Part of MRGFY-7580.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
