### PR TITLE
feat(flaky-detection): Add mark to exclude tests from flaky-detection reruns

### DIFF
--- a/pytest_mergify/__init__.py
+++ b/pytest_mergify/__init__.py
@@ -28,6 +28,11 @@ class PytestMergify:
     mergify_ci: MergifyCIInsights
 
     def pytest_configure(self, config: _pytest.config.Config) -> None:
+        config.addinivalue_line(
+            "markers",
+            "mergify(reruns=bool): Mergify per-test options. "
+            "Set reruns=False to disable reruns for the test.",
+        )
         kwargs = {}
         api_url = config.getoption("--mergify-api-url")
         if api_url is not None:

--- a/pytest_mergify/flaky_detection.py
+++ b/pytest_mergify/flaky_detection.py
@@ -242,17 +242,22 @@ class FlakyDetector:
             if test in tests_in_session
         ]
 
+        excluded_tests = {
+            item.nodeid for item in session.items if not _should_rerun_item(item)
+        }
+
         if self.mode == "new":
             self._tests_to_process = [
                 test
                 for test in tests_in_session
-                if test not in existing_tests_in_session
+                if test not in existing_tests_in_session and test not in excluded_tests
             ]
         elif self.mode == "unhealthy":
             self._tests_to_process = [
                 test
                 for test in tests_in_session
                 if test in self._context.unhealthy_test_names
+                and test not in excluded_tests
             ]
 
         if self.mode == "new":
@@ -619,3 +624,10 @@ def make_report_from_aggregated(
             result += f"{os.linesep}{json.dumps(log)}"
 
     return result
+
+
+def _should_rerun_item(item: _pytest.nodes.Item) -> bool:
+    """Whether a test may be rerun. Opt out via
+    `@pytest.mark.mergify(reruns=False)`."""
+    marker = item.get_closest_marker("mergify")
+    return marker is None or marker.kwargs.get("reruns", True) is not False

--- a/tests/test_ci_insights.py
+++ b/tests/test_ci_insights.py
@@ -717,3 +717,59 @@ def test_empty_base_ref_falls_through_to_head_ref(
     assert plugin.mergify_ci.branch_name == "main"
     assert plugin.mergify_ci.flaky_detector is not None
     assert plugin.mergify_ci.flaky_detector.mode == "unhealthy"
+
+
+@responses.activate
+def test_flaky_detection_excludes_opted_out_tests(
+    monkeypatch: pytest.MonkeyPatch,
+    pytester_with_spans: conftest.PytesterWithSpanT,
+) -> None:
+    _set_test_environment(monkeypatch)
+    _make_quarantine_mock()
+    # A non-empty baseline so `new` mode loads; it is absent from the session.
+    _make_flaky_detection_context_mock(
+        existing_test_names=["baseline.py::test_baseline"],
+    )
+
+    result, spans = pytester_with_spans(
+        code="""
+        import pytest
+
+        def test_watched():
+            assert True
+
+        @pytest.mark.mergify(reruns=False)
+        def test_excluded():
+            assert True
+        """
+    )
+
+    result.assert_outcomes(
+        # test_watched: 1 initial + 1000 reruns; test_excluded: 1 (not rerun).
+        passed=1002,
+    )
+
+    # Only test_watched is rerun; test_excluded is absent from the report.
+    assert re.search(
+        r"""🐛 Flaky detection
+- Used [0-9.]+ % of the budget \([0-9.]+ s/[0-9.]+ s\)
+- Active for 1 new test:
+    • 'test_flaky_detection_excludes_opted_out_tests\.py::test_watched' has been tested \d+ times using approx\. [0-9.]+ % of the budget \([0-9.]+ s/[0-9.]+ s\)""",
+        result.stdout.str(),
+        re.MULTILINE,
+    )
+
+    assert spans is not None
+    assert len(spans) == 1 + 2  # 1 for the session and one per test.
+
+    watched = spans["test_flaky_detection_excludes_opted_out_tests.py::test_watched"]
+    assert watched.attributes is not None
+    assert watched.attributes.get("cicd.test.new") is True
+    assert watched.attributes.get("cicd.test.flaky_detection") is True
+    assert watched.attributes.get("cicd.test.rerun_count") == 1000
+
+    excluded = spans["test_flaky_detection_excludes_opted_out_tests.py::test_excluded"]
+    assert excluded.attributes is not None
+    assert excluded.attributes.get("cicd.test.new") is None
+    assert excluded.attributes.get("cicd.test.flaky_detection") is None
+    assert excluded.attributes.get("cicd.test.rerun_count") is None


### PR DESCRIPTION
Some tests do not benefit from rerun-based flaky detection: migration tests,
expensive integration tests, or tests whose nodeid embeds a volatile value
(e.g. a commit SHA in a parametrize id) that makes `new` mode flag them as new
on every run and rerun them pointlessly.

Provide `@pytest.mark.mergify(reruns=False)` so authors can opt a test out of
the rerun loop in every mode, without disabling the plugin or altering the
test's identity.