### PR TITLE
refactor(flaky-detection): Rename `reruns` mark option to `flaky_detection`

### DIFF
--- a/pytest_mergify/__init__.py
+++ b/pytest_mergify/__init__.py
@@ -30,8 +30,8 @@ class PytestMergify:
     def pytest_configure(self, config: _pytest.config.Config) -> None:
         config.addinivalue_line(
             "markers",
-            "mergify(reruns=bool): Mergify per-test options. "
-            "Set reruns=False to disable reruns for the test.",
+            "mergify(flaky_detection=bool): Mergify per-test options. "
+            "Set flaky_detection=False to disable flaky detection for the test.",
         )
         kwargs = {}
         api_url = config.getoption("--mergify-api-url")

--- a/pytest_mergify/flaky_detection.py
+++ b/pytest_mergify/flaky_detection.py
@@ -243,7 +243,7 @@ class FlakyDetector:
         ]
 
         excluded_tests = {
-            item.nodeid for item in session.items if not _should_rerun_item(item)
+            item.nodeid for item in session.items if _flaky_detection_disabled(item)
         }
 
         if self.mode == "new":
@@ -626,8 +626,8 @@ def make_report_from_aggregated(
     return result
 
 
-def _should_rerun_item(item: _pytest.nodes.Item) -> bool:
-    """Whether a test may be rerun. Opt out via
-    `@pytest.mark.mergify(reruns=False)`."""
+def _flaky_detection_disabled(item: _pytest.nodes.Item) -> bool:
+    """Whether a test disabled flaky detection via
+    `@pytest.mark.mergify(flaky_detection=False)`."""
     marker = item.get_closest_marker("mergify")
-    return marker is None or marker.kwargs.get("reruns", True) is not False
+    return marker is not None and marker.kwargs.get("flaky_detection", True) is False

--- a/tests/test_ci_insights.py
+++ b/tests/test_ci_insights.py
@@ -738,7 +738,7 @@ def test_flaky_detection_excludes_opted_out_tests(
         def test_watched():
             assert True
 
-        @pytest.mark.mergify(reruns=False)
+        @pytest.mark.mergify(flaky_detection=False)
         def test_excluded():
             assert True
         """


### PR DESCRIPTION
The per-test opt-out shipped as `@pytest.mark.mergify(reruns=False)` in #441.
Rename it to `flaky_detection=False`: the option governs Mergify's
flaky-detection reruns specifically, so a `flaky_detection` name makes that
scope explicit and avoids confusion with generic rerun plugins such as
pytest-rerunfailures.