### PR TITLE
ci(mergify): Re-request devs review until required approvals are met

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -24,7 +24,7 @@ pull_request_rules:
           - check-success = test (3.13)
           - check-success = test (3.14)
           - check-success = codespell
-      - "#approved-reviews-by=0"
+      - "#approved-reviews-by < 2"
       - "#changes-requested-reviews-by=0"
       - review-requested != @devs
     actions:


### PR DESCRIPTION
The request-review rule stopped requesting @devs after the first approval (#approved-reviews-by=0), yet the Approval merge protection requires two. A pull request would silently stall after review #1 with no reviewer requested for review #2.

Match the monorepo behavior: keep re-requesting @devs while below the two-approval requirement (#approved-reviews-by < 2). When a dev reviews, GitHub drops the team request and Mergify automatically re-adds it until the merge gate is satisfied.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>