### PR TITLE
feat: run only the reduced test selection served by Mergify

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ More information at https://mergify.com
 - **Test tracing** — Sends OpenTelemetry traces for every test to Mergify's API
 - **Flaky test detection** — Intelligently reruns tests to detect flakiness with budget constraints
 - **Test quarantine** — Quarantines failing tests so they don't block CI
+- **Test selection** — Runs only the previously-failing tests when Mergify's merge queue reruns a job
 
 ## Installation
 
@@ -36,8 +37,28 @@ The plugin activates automatically when running in CI (detected via the `CI` env
 | `PYTEST_MERGIFY_DEBUG` | Print spans to console | `false` |
 | `MERGIFY_TRACEPARENT` | W3C distributed trace context | — |
 | `MERGIFY_TEST_JOB_NAME` | Mergify test job name | — |
+| `MERGIFY_TEST_SELECTION_DISABLE` | Opt out of test selection (see below) | `false` |
 
 For detailed documentation, see the [official guide](https://docs.mergify.com/ci-insights/test-frameworks/pytest/).
+
+### Test selection
+
+When Mergify's merge queue reruns a job — a retry, or a step of a batch
+bisection — only the tests that failed on the previous attempt are
+informative. The plugin asks Mergify whether the current run is such a rerun
+and, if so, runs only those tests; the rest are reported as deselected.
+
+Nothing to configure: the plugin uses the token and job identity it already
+has, and Mergify decides. Any other situation — a normal run, a rerun Mergify
+has no previous results for, an unreachable API — runs the full suite, so the
+feature can only remove work, never coverage. The feature is also enabled per
+organization on Mergify's side, so it stays inactive until your organization
+is opted in.
+
+Set `MERGIFY_TEST_SELECTION_DISABLE=true` in your CI to opt out: the plugin
+then always runs the full suite and never queries the endpoint. It is scoped
+to this feature only — test tracing, flaky detection and quarantine keep
+working (unset `MERGIFY_TOKEN` to turn the plugin off entirely).
 
 ## Development
 

--- a/pytest_mergify/__init__.py
+++ b/pytest_mergify/__init__.py
@@ -141,6 +141,15 @@ class PytestMergify:
                     self.mergify_ci.quarantined_tests.quarantined_tests_report()
                 )
 
+        # Mergify test selection (reduced merge-queue reruns) logs
+        if self.mergify_ci.test_selection is not None:
+            if self.mergify_ci.test_selection.init_error_msg:
+                terminalreporter.write_line(
+                    self.mergify_ci.test_selection.init_error_msg, yellow=True
+                )
+            else:
+                terminalreporter.write_line(self.mergify_ci.test_selection.report())
+
         # Mergify Test Insights Traces upload logs
         if self.mergify_ci.tracer_provider is None:
             terminalreporter.write_line(
@@ -188,6 +197,17 @@ class PytestMergify:
                 context=ctx if traceparent else None,
             )
         self.has_error = False
+
+    @pytest.hookimpl(trylast=True)
+    def pytest_collection_modifyitems(
+        self,
+        config: _pytest.config.Config,
+        items: typing.List[_pytest.nodes.Item],
+    ) -> None:
+        # trylast so user filters (-k, -m, --deselect) apply first; the
+        # reduced-rerun subset then only ever narrows what remains.
+        if self.mergify_ci.test_selection:
+            self.mergify_ci.test_selection.filter_items(config, items)
 
     def pytest_collection_finish(self, session: _pytest.main.Session) -> None:
         if self.mergify_ci.flaky_detector:

--- a/pytest_mergify/ci_insights.py
+++ b/pytest_mergify/ci_insights.py
@@ -11,9 +11,10 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
     OTLPSpanExporter,
 )
 from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor, TracerProvider, export
-from opentelemetry.semconv._incubating.attributes import vcs_attributes
+from opentelemetry.semconv._incubating.attributes import cicd_attributes, vcs_attributes
 
 import pytest_mergify.quarantine
+import pytest_mergify.test_selection
 import pytest_mergify.resources.ci as resources_ci
 import pytest_mergify.resources.git as resources_git
 import pytest_mergify.resources.github_actions as resources_gha
@@ -91,6 +92,13 @@ class MergifyCIInsights:
     )
 
     quarantined_tests: typing.Optional[pytest_mergify.quarantine.Quarantine] = (
+        dataclasses.field(
+            init=False,
+            default=None,
+        )
+    )
+
+    test_selection: typing.Optional[pytest_mergify.test_selection.TestSelection] = (
         dataclasses.field(
             init=False,
             default=None,
@@ -179,6 +187,52 @@ class MergifyCIInsights:
                 self.repo_name,
                 self.branch_name,
             )
+
+        self._load_test_selection(resource)
+
+    def _load_test_selection(
+        self, resource: opentelemetry.sdk.resources.Resource
+    ) -> None:
+        try:
+            disabled = utils.strtobool(
+                os.environ.get("MERGIFY_TEST_SELECTION_DISABLE", "false")
+            )
+        except ValueError:
+            # A kill switch must never crash pytest startup: any value we
+            # cannot parse reads as an attempt to disable.
+            disabled = True
+
+        if (
+            self.token is None
+            or self.repo_name is None
+            or disabled
+            # On xdist workers the controller already filtered the collection.
+            or os.environ.get("PYTEST_XDIST_WORKER") is not None
+        ):
+            return
+
+        # The selection is keyed on the run's OWN identity: the head branch
+        # and head revision (a merge-queue draft branch on reruns) plus the
+        # job coordinates — the exact values this plugin reports with each
+        # uploaded test, so the server can match its records.
+        head_branch = resource.attributes.get(vcs_attributes.VCS_REF_HEAD_NAME)
+        head_sha = resource.attributes.get(vcs_attributes.VCS_REF_HEAD_REVISION)
+        pipeline_name = resource.attributes.get(cicd_attributes.CICD_PIPELINE_NAME)
+        job_name = resource.attributes.get(
+            "mergify.test.job.name"
+        ) or resource.attributes.get(cicd_attributes.CICD_PIPELINE_TASK_NAME)
+        if not (head_branch and head_sha and pipeline_name and job_name):
+            return
+
+        self.test_selection = pytest_mergify.test_selection.TestSelection(
+            api_url=self.api_url,
+            token=self.token,
+            repo_name=self.repo_name,
+            branch_name=str(head_branch),
+            head_sha=str(head_sha),
+            pipeline_name=str(pipeline_name),
+            job_name=str(job_name),
+        )
 
     def _load_flaky_detector(
         self,

--- a/pytest_mergify/test_selection.py
+++ b/pytest_mergify/test_selection.py
@@ -1,0 +1,131 @@
+import dataclasses
+import typing
+
+import _pytest.config
+import _pytest.nodes
+import requests
+
+
+@dataclasses.dataclass
+class TestSelection:
+    """Ask Mergify whether this run should execute only a subset of tests.
+
+    A merge-queue rerun (a `max_checks_retries` attempt or a bisection step)
+    only needs to replay the tests that failed on the previous attempt.
+    Mergify resolves that server-side from the run's own identity (queue
+    branch + head SHA + job); the plugin sends what it already knows and
+    applies the answer to the collection. Every error, timeout, or unknown
+    situation degrades to running the full suite — this feature can only
+    remove work, never correctness.
+    """
+
+    api_url: str
+    token: str
+    repo_name: str
+    branch_name: str
+    head_sha: str
+    pipeline_name: str
+    job_name: str
+
+    selection: typing.Literal["full", "subset"] = dataclasses.field(
+        init=False, default="full"
+    )
+    reason: str = dataclasses.field(init=False, default="not_requested")
+    tests: typing.List[str] = dataclasses.field(init=False, default_factory=list)
+    init_error_msg: typing.Optional[str] = dataclasses.field(init=False, default=None)
+    kept_count: typing.Optional[int] = dataclasses.field(init=False, default=None)
+    deselected_count: int = dataclasses.field(init=False, default=0)
+
+    def __post_init__(self) -> None:
+        try:
+            owner, repository = self.repo_name.split("/")
+        except ValueError:
+            self.init_error_msg = f"Repository name '{self.repo_name}' has an unexpected format (expected 'owner/repository'), skipping Mergify test selection"
+            return
+
+        try:
+            response = requests.get(
+                f"{self.api_url}/v1/ci/{owner}/repositories/{repository}/test-selection",
+                headers={"Authorization": f"Bearer {self.token}"},
+                params={
+                    "branch": self.branch_name,
+                    "head_sha": self.head_sha,
+                    "pipeline_name": self.pipeline_name,
+                    "job_name": self.job_name,
+                },
+                timeout=10,
+            )
+        except requests.RequestException as exc:
+            self.init_error_msg = f"Failed to connect to Mergify's API, the full test suite will run. Error: {str(exc)}"
+            return
+
+        if response.status_code in (402, 404):
+            # No subscription, or an engine without the endpoint: silently
+            # run the full suite.
+            return
+
+        try:
+            response.raise_for_status()
+            payload = response.json()
+            selection = payload["selection"]
+            reason = payload["reason"]
+            # The response is polymorphic on `selection`: `tests` is part of a
+            # `subset` answer and absent from a `full` one. Reading it only for
+            # a subset mirrors that, and keeps the KeyError below meaningful --
+            # a subset with no `tests` is a real protocol break worth surfacing,
+            # which a blanket `.get("tests", [])` would silently run past.
+            tests = payload["tests"] if selection == "subset" else []
+        except (
+            requests.HTTPError,
+            requests.exceptions.JSONDecodeError,
+            KeyError,
+            # A payload that is valid JSON but not an object (list, string,
+            # number...) raises TypeError on subscript access.
+            TypeError,
+        ) as exc:
+            self.init_error_msg = f"Error when querying Mergify's API, the full test suite will run. Error: {str(exc)}"
+            return
+
+        if selection == "subset" and tests:
+            self.selection = "subset"
+            self.tests = tests
+        self.reason = str(reason)
+
+    def filter_items(
+        self,
+        config: _pytest.config.Config,
+        items: typing.List[_pytest.nodes.Item],
+    ) -> None:
+        """Reduce the collected items to the served subset, in place.
+
+        Matching is by exact nodeid — the identifiers Mergify serves are the
+        ones this plugin previously uploaded. Served names absent from the
+        collection are ignored; if NOTHING matches (e.g. the tests were
+        renamed since the previous attempt), the full suite runs — an empty
+        reduced run would turn green without testing anything.
+        """
+        if self.selection != "subset":
+            return
+
+        subset = set(self.tests)
+        kept = [item for item in items if item.nodeid in subset]
+        if not kept:
+            self.selection = "full"
+            self.reason = "subset_matched_no_collected_test"
+            return
+
+        deselected = [item for item in items if item.nodeid not in subset]
+        if deselected:
+            items[:] = kept
+            config.hook.pytest_deselected(items=deselected)
+
+        self.kept_count = len(kept)
+        self.deselected_count = len(deselected)
+
+    def report(self) -> str:
+        report_str = f"""✂️ Test selection
+- Selection: {self.selection} (reason: {self.reason})
+"""
+        if self.selection == "subset" and self.kept_count is not None:
+            report_str += f"- Reduced rerun: executing {self.kept_count} previously-failing test(s), {self.deselected_count} deselected\n"
+        return report_str

--- a/tests/test_test_selection.py
+++ b/tests/test_test_selection.py
@@ -1,0 +1,193 @@
+import dataclasses
+import typing
+
+import responses
+
+from pytest_mergify import test_selection
+
+
+API_URL = "https://example.com"
+ENDPOINT = f"{API_URL}/v1/ci/owner/repositories/repo/test-selection"
+
+
+def _make_selection() -> test_selection.TestSelection:
+    return test_selection.TestSelection(
+        api_url=API_URL,
+        token="token",
+        repo_name="owner/repo",
+        branch_name="mergify/merge-queue/abc",
+        head_sha="1" * 40,
+        pipeline_name="ci",
+        job_name="unit-tests",
+    )
+
+
+@dataclasses.dataclass
+class FakeItem:
+    nodeid: str
+
+
+class FakeHook:
+    def __init__(self) -> None:
+        self.deselected: typing.List[FakeItem] = []
+
+    def pytest_deselected(self, items: typing.List[FakeItem]) -> None:
+        self.deselected.extend(items)
+
+
+@dataclasses.dataclass
+class FakeConfig:
+    hook: FakeHook = dataclasses.field(default_factory=FakeHook)
+
+
+@responses.activate
+def test_subset_is_applied_to_the_collection() -> None:
+    responses.add(
+        responses.GET,
+        ENDPOINT,
+        json={
+            "selection": "subset",
+            "reason": "reduced_rerun",
+            "tests": ["tests/a.py::test_broken", "tests/b.py::test_gone"],
+        },
+    )
+    selection = _make_selection()
+    assert selection.selection == "subset"
+
+    items = [
+        FakeItem("tests/a.py::test_broken"),
+        FakeItem("tests/a.py::test_fine"),
+        FakeItem("tests/c.py::test_other"),
+    ]
+    config = FakeConfig()
+    selection.filter_items(config, items)  # type: ignore[arg-type]
+
+    assert [item.nodeid for item in items] == ["tests/a.py::test_broken"]
+    assert [item.nodeid for item in config.hook.deselected] == [
+        "tests/a.py::test_fine",
+        "tests/c.py::test_other",
+    ]
+    assert selection.kept_count == 1
+    assert selection.deselected_count == 2
+
+
+@responses.activate
+def test_subset_matching_nothing_falls_back_to_full() -> None:
+    responses.add(
+        responses.GET,
+        ENDPOINT,
+        json={
+            "selection": "subset",
+            "reason": "reduced_rerun",
+            "tests": ["tests/renamed.py::test_gone"],
+        },
+    )
+    selection = _make_selection()
+
+    items = [FakeItem("tests/a.py::test_fine")]
+    config = FakeConfig()
+    selection.filter_items(config, items)  # type: ignore[arg-type]
+
+    assert selection.selection == "full"
+    assert selection.reason == "subset_matched_no_collected_test"
+    assert [item.nodeid for item in items] == ["tests/a.py::test_fine"]
+    assert config.hook.deselected == []
+
+
+@responses.activate
+def test_full_response_leaves_the_collection_untouched() -> None:
+    # The engine serves a polymorphic response: `tests` is absent on `full`.
+    responses.add(
+        responses.GET,
+        ENDPOINT,
+        json={"selection": "full", "reason": "no_predecessor"},
+    )
+    selection = _make_selection()
+
+    items = [FakeItem("tests/a.py::test_fine")]
+    config = FakeConfig()
+    selection.filter_items(config, items)  # type: ignore[arg-type]
+
+    assert selection.selection == "full"
+    assert selection.reason == "no_predecessor"
+    assert len(items) == 1
+    assert config.hook.deselected == []
+
+
+@responses.activate
+def test_full_response_from_an_older_engine_is_not_an_error() -> None:
+    """An engine predating the polymorphic response still sends `tests: []`.
+
+    The plugin and the engine ship independently, so both shapes are live at
+    once. The old one must stay a plain `full` answer — not the API-error path,
+    which would print a scary (and false) warning on every run.
+    """
+    responses.add(
+        responses.GET,
+        ENDPOINT,
+        json={"selection": "full", "reason": "no_predecessor", "tests": []},
+    )
+    selection = _make_selection()
+
+    assert selection.selection == "full"
+    assert selection.reason == "no_predecessor"
+    assert selection.init_error_msg is None
+
+
+@responses.activate
+def test_subset_without_tests_is_surfaced_as_an_error() -> None:
+    """A `subset` answer must carry `tests`; if it does not, say so.
+
+    The full suite runs either way, so this costs nothing to get wrong quietly
+    -- which is exactly why it is worth a test. `tests` is only optional on a
+    `full` answer; missing it on a subset means the engine broke its own
+    contract, and a plugin that shrugged at that would hide a real bug behind a
+    normal-looking run.
+    """
+    responses.add(
+        responses.GET,
+        ENDPOINT,
+        json={"selection": "subset", "reason": "reduced_rerun"},
+    )
+    selection = _make_selection()
+
+    assert selection.selection == "full"
+    assert selection.init_error_msg is not None
+
+
+@responses.activate
+def test_http_error_degrades_to_full() -> None:
+    responses.add(responses.GET, ENDPOINT, status=500)
+    selection = _make_selection()
+
+    assert selection.selection == "full"
+    assert selection.init_error_msg is not None
+
+
+@responses.activate
+def test_missing_endpoint_degrades_silently_to_full() -> None:
+    responses.add(responses.GET, ENDPOINT, status=404)
+    selection = _make_selection()
+
+    assert selection.selection == "full"
+    assert selection.init_error_msg is None
+
+
+@responses.activate
+def test_connection_error_degrades_to_full() -> None:
+    # No responses registered → ConnectionError raised by the responses lib.
+    selection = _make_selection()
+
+    assert selection.selection == "full"
+    assert selection.init_error_msg is not None
+
+
+@responses.activate
+def test_non_object_payload_degrades_to_full() -> None:
+    # Valid JSON but not an object: subscript access raises TypeError,
+    # which must degrade to the full suite instead of crashing startup.
+    responses.add(responses.GET, ENDPOINT, json=["unexpected", "shape"])
+    selection = _make_selection()
+
+    assert selection.selection == "full"
+    assert selection.init_error_msg is not None


### PR DESCRIPTION
When a merge-queue batch fails and Mergify reruns it (bisection or `max_checks_retries`), the rerun does not need to execute the whole suite: only the tests that failed on the predecessor run are informative. This PR makes pytest-mergify ask the new Mergify *test selection* endpoint whether the current run is such a reduced rerun, and if so deselects everything but the previously-failing tests.

## How it works

- At session start (same conditions as the trace upload: API token + repo configured), the plugin calls `GET /v1/ci/{owner}/repositories/{repo}/test-selection` with the run's branch, head SHA, pipeline name and job name — the exact identity keys the uploaded test results are stored under.
- The endpoint answers `selection: subset` with a list of test ids, or `selection: full`. The server owns the whole policy (\"is this a merge-queue rerun?\", \"do I have the predecessor's results?\"); the plugin just obeys. Anything other than a clean `subset` answer — HTTP error, timeout, feature disabled, unknown response — falls back to running the full suite, so the plugin can never lose test coverage.
- On `subset`, `pytest_collection_modifyitems` keeps only the selected node ids (properly reported as deselected), and the terminal summary prints a `✂️ Test selection` section stating what was selected and why.

## Safety rails

- Kill switch: `MERGIFY_TEST_SELECTION_DISABLE=1` skips the endpoint call entirely.
- `pytest-xdist` workers never query the endpoint (only the controller would).
- If the served subset matches zero collected tests (e.g. test renamed between runs), the plugin runs the full suite instead of running nothing.
- Server-side, the feature is behind a Mergify feature flag; without it the endpoint always answers `full`.

Server side: Mergifyio/monorepo#36661.

Validated end-to-end on a real GitHub Actions runner against a live engine: a merge-queue retry draft PR collected 4 tests, deselected 2 and ran only the 2 previously-failing ones (`Selection: subset (reason: reduced_rerun)`), with the full suite correctly restored on normal runs.

Related to MRGFY-7854

🤖 Generated with [Claude Code](https://claude.com/claude-code)