### PR TITLE
fix(flaky-detection): Count only call-phase outcomes in the flaky verdict

### DIFF
--- a/pytest_mergify/__init__.py
+++ b/pytest_mergify/__init__.py
@@ -326,10 +326,9 @@ class PytestMergify:
         """Run initial test and flaky detection reruns. Returns (outcomes, rerun_count)."""
         distinct_outcomes: typing.Set[str] = set()
 
-        for report in _pytest.runner.runtestprotocol(
-            item=item, nextitem=nextitem, log=True
-        ):
-            distinct_outcomes.add(report.outcome)
+        distinct_outcomes |= _call_outcomes(
+            _pytest.runner.runtestprotocol(item=item, nextitem=nextitem, log=True)
+        )
 
         if (
             not self.mergify_ci.flaky_detector
@@ -355,8 +354,7 @@ class PytestMergify:
 
             # Always execute a last rerun before stopping to properly
             # restore finalizers. Otherwise, it can lead to resource leaks.
-            for report in self._reruntestprotocol(item, nextitem):
-                distinct_outcomes.add(report.outcome)
+            distinct_outcomes |= _call_outcomes(self._reruntestprotocol(item, nextitem))
 
             rerun_count += 1
 
@@ -529,6 +527,19 @@ def pytest_configure(config: _pytest.config.Config) -> None:
             return
 
     config.pluginmanager.register(PytestMergify(), name="PytestMergify")
+
+
+def _call_outcomes(
+    reports: typing.List[_pytest.reports.TestReport],
+) -> typing.Set[str]:
+    """
+    Outcomes of the call phase only.
+
+    Setup and teardown report "passed" for every test that runs, so counting
+    them would make a test that never once passed look like it both passed and
+    failed.
+    """
+    return {report.outcome for report in reports if report.when == "call"}
 
 
 def _should_skip_item(item: _pytest.nodes.Item) -> bool:

--- a/tests/test_ci_insights.py
+++ b/tests/test_ci_insights.py
@@ -540,6 +540,45 @@ def test_flaky_detection_slow_test_not_reran(
 
 
 @responses.activate
+def test_flaky_detection_consistent_failure_is_not_flaky(
+    monkeypatch: pytest.MonkeyPatch,
+    pytester_with_spans: conftest.PytesterWithSpanT,
+) -> None:
+    "Test that a test failing every single time is reported as broken, not flaky."
+    _set_test_environment(monkeypatch)
+    _make_quarantine_mock()
+    _make_flaky_detection_context_mock(
+        existing_test_names=[
+            "test_flaky_detection_consistent_failure_is_not_flaky.py::test_existing",
+        ],
+        max_test_execution_count=3,
+        min_test_execution_count=1,
+    )
+
+    _, spans = pytester_with_spans(
+        code="""
+        def test_existing():
+            assert True
+
+        def test_always_fails():
+            assert False
+        """
+    )
+
+    assert spans is not None
+    span = spans[
+        "test_flaky_detection_consistent_failure_is_not_flaky.py::test_always_fails"
+    ]
+    assert span.attributes is not None
+
+    # The test was reran, so flaky detection did consider it...
+    assert span.attributes.get("cicd.test.flaky_detection") is True
+    assert span.attributes.get("test.case.result.status") == "failed"
+    # ...but it never passed once, so it is broken rather than flaky.
+    assert span.attributes.get("cicd.test.flaky") is None
+
+
+@responses.activate
 def test_flaky_detection_budget_deadline_stops_reruns(
     monkeypatch: pytest.MonkeyPatch,
     pytester: _pytest.pytester.Pytester,


### PR DESCRIPTION
`runtestprotocol` returns one report per phase, and a successful setup always
reports "passed". Feeding every phase into the outcome set made
`"failed" in outcomes and "passed" in outcomes` collapse to "failed at least
once", so a test that never passed a single time was uploaded with
`cicd.test.flaky = True`.

The attribute is authoritative — the backend trusts it rather than recomputing
flakiness from the execution spans — so a deterministically broken new test was
recorded as flaky, inverting the signal flaky detection exists to provide.