### PR TITLE
fix(flaky-detection): Decide a test is too slow before suspending its finalizers

### DIFF
--- a/pytest_mergify/__init__.py
+++ b/pytest_mergify/__init__.py
@@ -336,13 +336,7 @@ class PytestMergify:
         ):
             return distinct_outcomes, 0
 
-        self.mergify_ci.flaky_detector.set_test_deadline(
-            test=item.nodeid,
-            timeout=datetime.timedelta(seconds=timeout_seconds)
-            if (timeout_seconds := pytest_timeout._get_item_settings(item).timeout)
-            else None,
-        )
-
+        # Decided at the first teardown, before any finalizer was suspended.
         if self.mergify_ci.flaky_detector.is_test_too_slow(item.nodeid):
             return distinct_outcomes, 0
 
@@ -417,18 +411,31 @@ class PytestMergify:
         self,
         item: _pytest.nodes.Item,
     ) -> None:
-        if (
-            not self.mergify_ci.flaky_detector
-            or not self.mergify_ci.flaky_detector.is_rerunning_test(item.nodeid)
-        ):
+        detector = self.mergify_ci.flaky_detector
+        if detector is None or not detector.is_rerunning_test(item.nodeid):
             return
+
+        if not detector.has_test_deadline(item.nodeid):
+            # First teardown for this test. Whether it gets rerun is decided
+            # here, before any finalizer moves: suspending for a test that is
+            # then skipped leaves higher-scoped finalizers outside pytest's
+            # stack with nothing left to restore them.
+            detector.set_test_deadline(
+                test=item.nodeid,
+                timeout=datetime.timedelta(seconds=timeout_seconds)
+                if (timeout_seconds := pytest_timeout._get_item_settings(item).timeout)
+                else None,
+            )
+
+            if detector.decide_test_is_too_slow(item.nodeid):
+                return
 
         # The goal here is to keep only function-scoped finalizers during
         # reruns and restore higher-scoped finalizers only on the last one.
         if item.keywords.get("is_last_rerun"):
-            self.mergify_ci.flaky_detector.restore_item_finalizers(item)
+            detector.restore_item_finalizers(item)
         else:
-            self.mergify_ci.flaky_detector.suspend_item_finalizers(item)
+            detector.suspend_item_finalizers(item)
 
     def pytest_exception_interact(
         self,

--- a/pytest_mergify/flaky_detection.py
+++ b/pytest_mergify/flaky_detection.py
@@ -76,6 +76,9 @@ class _TestMetrics:
 
     prevented_timeout: bool = dataclasses.field(default=False)
 
+    too_slow: bool = dataclasses.field(default=False)
+    "Whether the test is too slow to be rerun, as decided at its first teardown."
+
     total_duration: datetime.timedelta = dataclasses.field(
         default_factory=datetime.timedelta
     )
@@ -290,13 +293,33 @@ class FlakyDetector:
             self._context.min_budget_duration,
         )
 
-    def is_test_too_slow(self, test: str) -> bool:
-        metrics = self._test_metrics[test]
+    def has_test_deadline(self, test: str) -> bool:
+        """Whether a deadline was already computed for this test."""
+        metrics = self._test_metrics.get(test)
 
-        return (
+        return metrics is not None and metrics.deadline is not None
+
+    def decide_test_is_too_slow(self, test: str) -> bool:
+        """
+        Decide whether the test can still be rerun enough times before its
+        deadline, and remember the answer.
+
+        The answer is only ever taken once. The estimate grows as the test runs
+        while the time left shrinks, so deciding again later can flip to `True`
+        after finalizers were already suspended for a rerun that then never
+        happens, leaving them stranded.
+        """
+        metrics = self._test_metrics[test]
+        metrics.too_slow = (
             metrics.initial_duration * self._context.min_test_execution_count
             > metrics.remaining_time()
         )
+
+        return metrics.too_slow
+
+    def is_test_too_slow(self, test: str) -> bool:
+        """The decision taken at the test's first teardown."""
+        return self._test_metrics[test].too_slow
 
     def is_test_rerun(self, test: str) -> bool:
         """Returns `True` if the test has already completed its initial run and is

--- a/tests/test_ci_insights.py
+++ b/tests/test_ci_insights.py
@@ -579,6 +579,126 @@ def test_flaky_detection_consistent_failure_is_not_flaky(
 
 
 @responses.activate
+def test_flaky_detection_slow_test_keeps_higher_scoped_finalizers(
+    monkeypatch: pytest.MonkeyPatch,
+    pytester: _pytest.pytester.Pytester,
+) -> None:
+    "Test that a test skipped for being too slow still tears down its module."
+    _set_test_environment(monkeypatch)
+    _make_quarantine_mock()
+    _make_flaky_detection_context_mock(
+        existing_test_names=[
+            "test_flaky_detection_slow_test_keeps_higher_scoped_finalizers.py::test_existing",
+        ],
+        min_test_execution_count=5,
+    )
+
+    class CustomPlugin:
+        def pytest_runtest_makereport(
+            self,
+            item: _pytest.nodes.Item,
+            call: _pytest.reports.TestReport,
+        ) -> None:
+            if call.when != "call":
+                return
+
+            if "test_slow" in item.nodeid:
+                call.duration = 10.0  # Simulate a slow test.
+            else:
+                call.duration = 0.001
+
+    # `test_slow` is last, so its teardown is the only chance the module-scoped
+    # finalizer gets to run.
+    pytester.makepyfile(
+        """
+        import pathlib
+
+        import pytest
+
+        @pytest.fixture(scope="module", autouse=True)
+        def _module_resource():
+            yield
+            pathlib.Path("module_teardown_ran").touch()
+
+        def test_existing():
+            assert True
+
+        def test_slow():
+            assert True
+        """
+    )
+
+    result = pytester.runpytest_inprocess(
+        plugins=[CustomPlugin(), pytest_mergify.PytestMergify()]
+    )
+    result.assert_outcomes(passed=2)
+
+    assert (
+        "'test_flaky_detection_slow_test_keeps_higher_scoped_finalizers.py::test_slow' is too slow"
+        in result.stdout.str()
+    )
+    assert (pytester.path / "module_teardown_ran").exists()
+
+
+@responses.activate
+def test_flaky_detection_slow_teardown_keeps_higher_scoped_finalizers(
+    monkeypatch: pytest.MonkeyPatch,
+    pytester: _pytest.pytester.Pytester,
+) -> None:
+    "Test that the too-slow verdict cannot flip after finalizers were suspended."
+    _set_test_environment(monkeypatch)
+    _make_quarantine_mock()
+    _make_flaky_detection_context_mock(
+        existing_test_names=[
+            "test_flaky_detection_slow_teardown_keeps_higher_scoped_finalizers.py::test_existing",
+        ],
+        min_test_execution_count=5,
+    )
+
+    # A cheap call with an expensive teardown: cheap enough to be reran when the
+    # verdict is taken, expensive enough to look too slow once the teardown is
+    # measured.
+    class CustomPlugin:
+        def pytest_runtest_makereport(
+            self,
+            item: _pytest.nodes.Item,
+            call: _pytest.reports.TestReport,
+        ) -> None:
+            if "test_slow" not in item.nodeid:
+                call.duration = 0.001
+            elif call.when == "teardown":
+                call.duration = 10.0
+            elif call.when == "call":
+                call.duration = 0.001
+
+    pytester.makepyfile(
+        """
+        import pathlib
+
+        import pytest
+
+        @pytest.fixture(scope="module", autouse=True)
+        def _module_resource():
+            yield
+            pathlib.Path("module_teardown_ran").touch()
+
+        def test_existing():
+            assert True
+
+        def test_slow():
+            assert True
+        """
+    )
+
+    result = pytester.runpytest_inprocess(
+        plugins=[CustomPlugin(), pytest_mergify.PytestMergify()]
+    )
+
+    assert (pytester.path / "module_teardown_ran").exists()
+    assert result.ret == 0
+
+
+@responses.activate
 def test_flaky_detection_budget_deadline_stops_reruns(
     monkeypatch: pytest.MonkeyPatch,
     pytester: _pytest.pytester.Pytester,


### PR DESCRIPTION
The initial teardown suspended every higher-scoped entry out of pytest's setup
stack, but the "too slow to rerun" check ran afterwards and returned early.
`restore_item_finalizers` is only reachable from the last-rerun branch, so a
test skipped for being too slow left its Session and Module finalizers stashed
and abandoned: they either never ran — `teardown_exact` only pops what is still
in the stack, so pytest reported nothing — or a later test in another module
restored them into its own stack and ran them mid-run.

The verdict now happens once, at the first teardown, before any finalizer moves,
and is remembered. Moving it alone was not enough: the estimate grows as the
test runs while the time left shrinks, so a second evaluation can only flip
towards "too slow", stranding the finalizers the first one had just suspended.
A test with a cheap call and an expensive teardown does exactly that.

Restoring on the early return instead would reinsert Session and Module into a
stack the next item may not descend from, tripping `SetupState.setup`'s
"previous item was not torn down properly" assertion at the next module
boundary.

Because the verdict is taken before the teardown report is logged, it no longer
counts the teardown phase; the deadline still bounds the rerun loop.

Depends-On: #465