### PR TITLE
fix(flaky-detection): Keep metrics for a test that skips part-way through its reruns

### DIFF
--- a/pytest_mergify/__init__.py
+++ b/pytest_mergify/__init__.py
@@ -336,13 +336,7 @@ class PytestMergify:
         ):
             return distinct_outcomes, 0
 
-        self.mergify_ci.flaky_detector.set_test_deadline(
-            test=item.nodeid,
-            timeout=datetime.timedelta(seconds=timeout_seconds)
-            if (timeout_seconds := pytest_timeout._get_item_settings(item).timeout)
-            else None,
-        )
-
+        # Decided at the first teardown, before any finalizer was suspended.
         if self.mergify_ci.flaky_detector.is_test_too_slow(item.nodeid):
             return distinct_outcomes, 0
 
@@ -417,18 +411,31 @@ class PytestMergify:
         self,
         item: _pytest.nodes.Item,
     ) -> None:
-        if (
-            not self.mergify_ci.flaky_detector
-            or not self.mergify_ci.flaky_detector.is_rerunning_test(item.nodeid)
-        ):
+        detector = self.mergify_ci.flaky_detector
+        if detector is None or not detector.is_rerunning_test(item.nodeid):
             return
+
+        if not detector.has_test_deadline(item.nodeid):
+            # First teardown for this test. Whether it gets rerun is decided
+            # here, before any finalizer moves: suspending for a test that is
+            # then skipped leaves higher-scoped finalizers outside pytest's
+            # stack with nothing left to restore them.
+            detector.set_test_deadline(
+                test=item.nodeid,
+                timeout=datetime.timedelta(seconds=timeout_seconds)
+                if (timeout_seconds := pytest_timeout._get_item_settings(item).timeout)
+                else None,
+            )
+
+            if detector.decide_test_is_too_slow(item.nodeid):
+                return
 
         # The goal here is to keep only function-scoped finalizers during
         # reruns and restore higher-scoped finalizers only on the last one.
         if item.keywords.get("is_last_rerun"):
-            self.mergify_ci.flaky_detector.restore_item_finalizers(item)
+            detector.restore_item_finalizers(item)
         else:
-            self.mergify_ci.flaky_detector.suspend_item_finalizers(item)
+            detector.suspend_item_finalizers(item)
 
     def pytest_exception_interact(
         self,

--- a/pytest_mergify/__init__.py
+++ b/pytest_mergify/__init__.py
@@ -326,10 +326,9 @@ class PytestMergify:
         """Run initial test and flaky detection reruns. Returns (outcomes, rerun_count)."""
         distinct_outcomes: typing.Set[str] = set()
 
-        for report in _pytest.runner.runtestprotocol(
-            item=item, nextitem=nextitem, log=True
-        ):
-            distinct_outcomes.add(report.outcome)
+        distinct_outcomes |= _call_outcomes(
+            _pytest.runner.runtestprotocol(item=item, nextitem=nextitem, log=True)
+        )
 
         if (
             not self.mergify_ci.flaky_detector
@@ -355,8 +354,7 @@ class PytestMergify:
 
             # Always execute a last rerun before stopping to properly
             # restore finalizers. Otherwise, it can lead to resource leaks.
-            for report in self._reruntestprotocol(item, nextitem):
-                distinct_outcomes.add(report.outcome)
+            distinct_outcomes |= _call_outcomes(self._reruntestprotocol(item, nextitem))
 
             rerun_count += 1
 
@@ -529,6 +527,19 @@ def pytest_configure(config: _pytest.config.Config) -> None:
             return
 
     config.pluginmanager.register(PytestMergify(), name="PytestMergify")
+
+
+def _call_outcomes(
+    reports: typing.List[_pytest.reports.TestReport],
+) -> typing.Set[str]:
+    """
+    Outcomes of the call phase only.
+
+    Setup and teardown report "passed" for every test that runs, so counting
+    them would make a test that never once passed look like it both passed and
+    failed.
+    """
+    return {report.outcome for report in reports if report.when == "call"}
 
 
 def _should_skip_item(item: _pytest.nodes.Item) -> bool:

--- a/pytest_mergify/flaky_detection.py
+++ b/pytest_mergify/flaky_detection.py
@@ -76,6 +76,9 @@ class _TestMetrics:
 
     prevented_timeout: bool = dataclasses.field(default=False)
 
+    too_slow: bool = dataclasses.field(default=False)
+    "Whether the test is too slow to be rerun, as decided at its first teardown."
+
     total_duration: datetime.timedelta = dataclasses.field(
         default_factory=datetime.timedelta
     )
@@ -290,13 +293,33 @@ class FlakyDetector:
             self._context.min_budget_duration,
         )
 
-    def is_test_too_slow(self, test: str) -> bool:
-        metrics = self._test_metrics[test]
+    def has_test_deadline(self, test: str) -> bool:
+        """Whether a deadline was already computed for this test."""
+        metrics = self._test_metrics.get(test)
 
-        return (
+        return metrics is not None and metrics.deadline is not None
+
+    def decide_test_is_too_slow(self, test: str) -> bool:
+        """
+        Decide whether the test can still be rerun enough times before its
+        deadline, and remember the answer.
+
+        The answer is only ever taken once. The estimate grows as the test runs
+        while the time left shrinks, so deciding again later can flip to `True`
+        after finalizers were already suspended for a rerun that then never
+        happens, leaving them stranded.
+        """
+        metrics = self._test_metrics[test]
+        metrics.too_slow = (
             metrics.initial_duration * self._context.min_test_execution_count
             > metrics.remaining_time()
         )
+
+        return metrics.too_slow
+
+    def is_test_too_slow(self, test: str) -> bool:
+        """The decision taken at the test's first teardown."""
+        return self._test_metrics[test].too_slow
 
     def is_test_rerun(self, test: str) -> bool:
         """Returns `True` if the test has already completed its initial run and is

--- a/pytest_mergify/flaky_detection.py
+++ b/pytest_mergify/flaky_detection.py
@@ -229,9 +229,15 @@ class FlakyDetector:
     def try_fill_metrics_from_report(self, report: _pytest.reports.TestReport) -> None:
         test = report.nodeid
 
-        if report.outcome == "skipped":
+        if report.outcome == "skipped" and not self.is_rerunning_test(test):
             # Remove metrics for skipped tests. Setup phase may have passed and
             # initialized metrics before call phase was skipped.
+            #
+            # Only before the test starts being rerun: from then on the metrics
+            # drive the rerun loop and the finalizer bookkeeping, so dropping
+            # them mid-loop crashes the session and strands the finalizers
+            # suspended for this test. A skip during a rerun is instead recorded
+            # like any other outcome, so it counts towards the execution limit.
             self._test_metrics.pop(test, None)
             return
 

--- a/tests/test_ci_insights.py
+++ b/tests/test_ci_insights.py
@@ -540,6 +540,45 @@ def test_flaky_detection_slow_test_not_reran(
 
 
 @responses.activate
+def test_flaky_detection_consistent_failure_is_not_flaky(
+    monkeypatch: pytest.MonkeyPatch,
+    pytester_with_spans: conftest.PytesterWithSpanT,
+) -> None:
+    "Test that a test failing every single time is reported as broken, not flaky."
+    _set_test_environment(monkeypatch)
+    _make_quarantine_mock()
+    _make_flaky_detection_context_mock(
+        existing_test_names=[
+            "test_flaky_detection_consistent_failure_is_not_flaky.py::test_existing",
+        ],
+        max_test_execution_count=3,
+        min_test_execution_count=1,
+    )
+
+    _, spans = pytester_with_spans(
+        code="""
+        def test_existing():
+            assert True
+
+        def test_always_fails():
+            assert False
+        """
+    )
+
+    assert spans is not None
+    span = spans[
+        "test_flaky_detection_consistent_failure_is_not_flaky.py::test_always_fails"
+    ]
+    assert span.attributes is not None
+
+    # The test was reran, so flaky detection did consider it...
+    assert span.attributes.get("cicd.test.flaky_detection") is True
+    assert span.attributes.get("test.case.result.status") == "failed"
+    # ...but it never passed once, so it is broken rather than flaky.
+    assert span.attributes.get("cicd.test.flaky") is None
+
+
+@responses.activate
 def test_flaky_detection_budget_deadline_stops_reruns(
     monkeypatch: pytest.MonkeyPatch,
     pytester: _pytest.pytester.Pytester,

--- a/tests/test_ci_insights.py
+++ b/tests/test_ci_insights.py
@@ -481,6 +481,61 @@ def test_flaky_detection_with_only_one_new_test_at_the_end(
 
 
 @responses.activate
+def test_flaky_detection_test_skipping_only_on_a_rerun(
+    monkeypatch: pytest.MonkeyPatch,
+    pytester: _pytest.pytester.Pytester,
+) -> None:
+    "Test that a test skipping part-way through its reruns stays recoverable."
+    _set_test_environment(monkeypatch)
+    _make_quarantine_mock()
+    _make_flaky_detection_context_mock(
+        existing_test_names=[
+            "test_flaky_detection_test_skipping_only_on_a_rerun.py::test_existing",
+        ],
+        max_test_execution_count=5,
+        min_test_execution_count=1,
+    )
+
+    pytester.makepyfile(
+        """
+        import pathlib
+
+        import pytest
+
+        EXECUTIONS = 0
+
+        @pytest.fixture(scope="module", autouse=True)
+        def _module_resource():
+            yield
+            pathlib.Path("module_teardown_ran").touch()
+
+        def test_existing():
+            assert True
+
+        def test_new():
+            global EXECUTIONS
+            EXECUTIONS += 1
+
+            # Passes once, then becomes unavailable — a service that went away,
+            # a container that stopped being ready.
+            if EXECUTIONS > 1:
+                pytest.skip("no longer available")
+        """
+    )
+
+    result = pytester.runpytest_inprocess(plugins=[pytest_mergify.PytestMergify()])
+
+    # The session completes rather than dying on a `KeyError`...
+    assert result.ret != pytest.ExitCode.INTERNAL_ERROR
+    assert "INTERNALERROR" not in result.stdout.str()
+    # ...and the finalizers suspended for the reruns are handed back.
+    assert (pytester.path / "module_teardown_ran").exists()
+    # ...and a skip still counts as an execution, so the test stops at the limit
+    # instead of rerunning a no-op until the budget runs out.
+    assert 0 < result.parseoutcomes()["skipped"] <= 5
+
+
+@responses.activate
 def test_flaky_detection_slow_test_not_reran(
     monkeypatch: pytest.MonkeyPatch,
     pytester: _pytest.pytester.Pytester,

--- a/tests/test_ci_insights.py
+++ b/tests/test_ci_insights.py
@@ -579,6 +579,126 @@ def test_flaky_detection_consistent_failure_is_not_flaky(
 
 
 @responses.activate
+def test_flaky_detection_slow_test_keeps_higher_scoped_finalizers(
+    monkeypatch: pytest.MonkeyPatch,
+    pytester: _pytest.pytester.Pytester,
+) -> None:
+    "Test that a test skipped for being too slow still tears down its module."
+    _set_test_environment(monkeypatch)
+    _make_quarantine_mock()
+    _make_flaky_detection_context_mock(
+        existing_test_names=[
+            "test_flaky_detection_slow_test_keeps_higher_scoped_finalizers.py::test_existing",
+        ],
+        min_test_execution_count=5,
+    )
+
+    class CustomPlugin:
+        def pytest_runtest_makereport(
+            self,
+            item: _pytest.nodes.Item,
+            call: _pytest.reports.TestReport,
+        ) -> None:
+            if call.when != "call":
+                return
+
+            if "test_slow" in item.nodeid:
+                call.duration = 10.0  # Simulate a slow test.
+            else:
+                call.duration = 0.001
+
+    # `test_slow` is last, so its teardown is the only chance the module-scoped
+    # finalizer gets to run.
+    pytester.makepyfile(
+        """
+        import pathlib
+
+        import pytest
+
+        @pytest.fixture(scope="module", autouse=True)
+        def _module_resource():
+            yield
+            pathlib.Path("module_teardown_ran").touch()
+
+        def test_existing():
+            assert True
+
+        def test_slow():
+            assert True
+        """
+    )
+
+    result = pytester.runpytest_inprocess(
+        plugins=[CustomPlugin(), pytest_mergify.PytestMergify()]
+    )
+    result.assert_outcomes(passed=2)
+
+    assert (
+        "'test_flaky_detection_slow_test_keeps_higher_scoped_finalizers.py::test_slow' is too slow"
+        in result.stdout.str()
+    )
+    assert (pytester.path / "module_teardown_ran").exists()
+
+
+@responses.activate
+def test_flaky_detection_slow_teardown_keeps_higher_scoped_finalizers(
+    monkeypatch: pytest.MonkeyPatch,
+    pytester: _pytest.pytester.Pytester,
+) -> None:
+    "Test that the too-slow verdict cannot flip after finalizers were suspended."
+    _set_test_environment(monkeypatch)
+    _make_quarantine_mock()
+    _make_flaky_detection_context_mock(
+        existing_test_names=[
+            "test_flaky_detection_slow_teardown_keeps_higher_scoped_finalizers.py::test_existing",
+        ],
+        min_test_execution_count=5,
+    )
+
+    # A cheap call with an expensive teardown: cheap enough to be reran when the
+    # verdict is taken, expensive enough to look too slow once the teardown is
+    # measured.
+    class CustomPlugin:
+        def pytest_runtest_makereport(
+            self,
+            item: _pytest.nodes.Item,
+            call: _pytest.reports.TestReport,
+        ) -> None:
+            if "test_slow" not in item.nodeid:
+                call.duration = 0.001
+            elif call.when == "teardown":
+                call.duration = 10.0
+            elif call.when == "call":
+                call.duration = 0.001
+
+    pytester.makepyfile(
+        """
+        import pathlib
+
+        import pytest
+
+        @pytest.fixture(scope="module", autouse=True)
+        def _module_resource():
+            yield
+            pathlib.Path("module_teardown_ran").touch()
+
+        def test_existing():
+            assert True
+
+        def test_slow():
+            assert True
+        """
+    )
+
+    result = pytester.runpytest_inprocess(
+        plugins=[CustomPlugin(), pytest_mergify.PytestMergify()]
+    )
+
+    assert (pytester.path / "module_teardown_ran").exists()
+    assert result.ret == 0
+
+
+@responses.activate
 def test_flaky_detection_budget_deadline_stops_reruns(
     monkeypatch: pytest.MonkeyPatch,
     pytester: _pytest.pytester.Pytester,


### PR DESCRIPTION
A skipped report dropped the test's metrics outright, to cover the case where
setup passed and initialised them before the call phase was skipped. That is
only correct before reruns begin. Once they have, the metrics drive the rerun
loop and the finalizer bookkeeping, so a test that passes its first execution
and then skips — an external service that went away, a container that stopped
being ready — takes the whole session down: the loop's next
`is_last_rerun_for_test` raises `KeyError` out of `pytest_runtest_protocol`.

The same drop silently defeats `pytest_runtest_teardown`, whose guard reads the
metrics that no longer exist, so the higher-scoped finalizers suspended for the
reruns are never handed back.

Restricting the drop to tests that are not being rerun fixes both, and keeps the
original setup-then-skip case working.

Depends-On: #466