### PR TITLE
refactor(flaky-detection): Name the two rerun predicates after what they answer

### DIFF
--- a/pytest_mergify/__init__.py
+++ b/pytest_mergify/__init__.py
@@ -332,7 +332,7 @@ class PytestMergify:
 
         if (
             not self.mergify_ci.flaky_detector
-            or not self.mergify_ci.flaky_detector.is_rerunning_test(item.nodeid)
+            or not self.mergify_ci.flaky_detector.has_test_executed(item.nodeid)
         ):
             return distinct_outcomes, 0
 
@@ -412,7 +412,7 @@ class PytestMergify:
         item: _pytest.nodes.Item,
     ) -> None:
         detector = self.mergify_ci.flaky_detector
-        if detector is None or not detector.is_rerunning_test(item.nodeid):
+        if detector is None or not detector.has_test_executed(item.nodeid):
             return
 
         if not detector.has_test_deadline(item.nodeid):
@@ -480,7 +480,7 @@ class PytestMergify:
 
         if (
             self.mergify_ci.flaky_detector
-            and self.mergify_ci.flaky_detector.is_test_rerun(report.nodeid)
+            and self.mergify_ci.flaky_detector.has_test_been_rerun(report.nodeid)
         ):
             return
 
@@ -507,7 +507,7 @@ class PytestMergify:
 
         if (
             self.mergify_ci.flaky_detector
-            and self.mergify_ci.flaky_detector.is_rerunning_test(report.nodeid)
+            and self.mergify_ci.flaky_detector.has_test_executed(report.nodeid)
         ):
             test_span.set_attributes({"cicd.test.flaky_detection": True})
             if self.mergify_ci.flaky_detector.mode == "new":

--- a/pytest_mergify/flaky_detection.py
+++ b/pytest_mergify/flaky_detection.py
@@ -229,7 +229,7 @@ class FlakyDetector:
     def try_fill_metrics_from_report(self, report: _pytest.reports.TestReport) -> None:
         test = report.nodeid
 
-        if report.outcome == "skipped" and not self.is_rerunning_test(test):
+        if report.outcome == "skipped" and not self.has_test_executed(test):
             # Remove metrics for skipped tests. Setup phase may have passed and
             # initialized metrics before call phase was skipped.
             #
@@ -327,14 +327,16 @@ class FlakyDetector:
         """The decision taken at the test's first teardown."""
         return self._test_metrics[test].too_slow
 
-    def is_test_rerun(self, test: str) -> bool:
-        """Returns `True` if the test has already completed its initial run and is
-        now in a rerun, `False` otherwise."""
+    def has_test_been_rerun(self, test: str) -> bool:
+        """Whether the test is past its initial execution, so the report or span
+        at hand belongs to a rerun rather than to the first run."""
         return (
             metrics := self._test_metrics.get(test)
         ) is not None and metrics.rerun_count > 1
 
-    def is_rerunning_test(self, test: str) -> bool:
+    def has_test_executed(self, test: str) -> bool:
+        """Whether flaky detection tracks this test and it has completed at
+        least one execution — the point from which it may be rerun."""
         return (
             metrics := self._test_metrics.get(test)
         ) is not None and metrics.rerun_count >= 1


### PR DESCRIPTION
`is_test_rerun` and `is_rerunning_test` differed by one character of name and by
one character of meaning — `> 1` against `>= 1` — while guarding different
things: whether the report at hand belongs to a rerun, and whether flaky
detection applies to the test at all. Neither name said which.

Every guard in the rerun protocol picks one of the pair, and picking the wrong
one is silent: the reruns still happen, only the reported outcome or the
finalizer bookkeeping is wrong. That is the failure mode behind several of the
fixes this subsystem has already needed.

Renamed to `has_test_been_rerun` and `has_test_executed`, both with a docstring
stating the condition. No behaviour change.

Note `_TestMetrics.rerun_count` counts *executions*, initial run included, so it
is misnamed too — left alone here because it crosses the xdist worker/controller
payload and deserves its own change.