### PR TITLE
refactor(flaky-detection): Keep the last-rerun flag out of pytest's keyword namespace

### DIFF
--- a/pytest_mergify/__init__.py
+++ b/pytest_mergify/__init__.py
@@ -346,10 +346,8 @@ class PytestMergify:
             return distinct_outcomes, 0
 
         rerun_count = 0
-        while not item.keywords.get("is_last_rerun"):
-            item.keywords["is_last_rerun"] = (
-                self.mergify_ci.flaky_detector.is_last_rerun_for_test(item.nodeid)
-            )
+        while not self.mergify_ci.flaky_detector.is_on_last_rerun(item.nodeid):
+            self.mergify_ci.flaky_detector.flag_last_rerun(item.nodeid)
 
             # Always execute a last rerun before stopping to properly
             # restore finalizers. Otherwise, it can lead to resource leaks.
@@ -437,7 +435,7 @@ class PytestMergify:
 
         # The goal here is to keep only function-scoped finalizers during
         # reruns and restore higher-scoped finalizers only on the last one.
-        if item.keywords.get("is_last_rerun"):
+        if detector.is_on_last_rerun(item.nodeid):
             detector.restore_item_finalizers(item)
         else:
             detector.suspend_item_finalizers(item)

--- a/pytest_mergify/flaky_detection.py
+++ b/pytest_mergify/flaky_detection.py
@@ -79,6 +79,9 @@ class _TestMetrics:
     too_slow: bool = dataclasses.field(default=False)
     "Whether the test is too slow to be rerun, as decided at its first teardown."
 
+    is_last_rerun: bool = dataclasses.field(default=False)
+    "Whether the rerun in progress is the last one, so teardown restores finalizers."
+
     total_duration: datetime.timedelta = dataclasses.field(
         default_factory=datetime.timedelta
     )
@@ -341,7 +344,17 @@ class FlakyDetector:
             metrics := self._test_metrics.get(test)
         ) is not None and metrics.rerun_count >= 1
 
-    def is_last_rerun_for_test(self, test: str) -> bool:
+    def flag_last_rerun(self, test: str) -> None:
+        """Record whether the rerun about to start is the last one for this test."""
+        self._test_metrics[test].is_last_rerun = self._reached_rerun_limit(test)
+
+    def is_on_last_rerun(self, test: str) -> bool:
+        """Whether the rerun in progress was flagged as the last one."""
+        metrics = self._test_metrics.get(test)
+
+        return metrics is not None and metrics.is_last_rerun
+
+    def _reached_rerun_limit(self, test: str) -> bool:
         metrics = self._test_metrics[test]
 
         will_exceed_deadline = metrics.will_exceed_deadline()

--- a/tests/test_ci_insights.py
+++ b/tests/test_ci_insights.py
@@ -545,6 +545,48 @@ def test_flaky_detection_with_only_one_new_test_at_the_end(
 
 
 @responses.activate
+def test_flaky_detection_keeps_its_state_out_of_report_keywords(
+    monkeypatch: pytest.MonkeyPatch,
+    pytester: _pytest.pytester.Pytester,
+) -> None:
+    "Test that rerun bookkeeping stays out of pytest's keyword namespace."
+    _set_test_environment(monkeypatch)
+    _make_quarantine_mock()
+    _make_flaky_detection_context_mock(
+        existing_test_names=[
+            "test_flaky_detection_keeps_its_state_out_of_report_keywords.py::test_existing",
+        ],
+        max_test_execution_count=3,
+        min_test_execution_count=1,
+    )
+
+    reported_keywords: typing.Set[str] = set()
+
+    class CustomPlugin:
+        def pytest_runtest_logreport(self, report: _pytest.reports.TestReport) -> None:
+            reported_keywords.update(report.keywords)
+
+    pytester.makepyfile(
+        """
+        def test_existing():
+            assert True
+
+        def test_new():
+            assert True
+        """
+    )
+
+    result = pytester.runpytest_inprocess(
+        plugins=[CustomPlugin(), pytest_mergify.PytestMergify()]
+    )
+    assert result.ret == 0
+
+    # `report.keywords` reaches `-k` matching, the xdist worker/controller
+    # payload and JUnit XML, so nothing internal belongs in it.
+    assert "is_last_rerun" not in reported_keywords
+
+
+@responses.activate
 def test_flaky_detection_test_skipping_only_on_a_rerun(
     monkeypatch: pytest.MonkeyPatch,
     pytester: _pytest.pytester.Pytester,


### PR DESCRIPTION
The rerun loop stored its bookkeeping in `item.keywords`, which is pytest's
own namespace: it is what `-k` matches against and it is copied wholesale into
every `TestReport`, so `is_last_rerun` travelled into the xdist worker payload
and into JUnit XML for anyone exporting it. It was also never cleared, leaving
load-bearing state in a structure this plugin does not own.

The flag now lives on the test's own metrics, beside the other per-test rerun
state, so it is scoped to the test and invisible to everything downstream.

`is_last_rerun_for_test` becomes `_reached_rerun_limit`, leaving `flag_last_rerun`
to record the decision and `is_on_last_rerun` to read it back. Naming them apart
matters: a stored flag sitting next to an identically-named computation is the
same trap the rerun predicates just came out of.

Depends-On: #469