### PR TITLE
fix(flaky-detection): Charge only rerun time to the flaky detection budget

### DIFF
--- a/pytest_mergify/flaky_detection.py
+++ b/pytest_mergify/flaky_detection.py
@@ -87,6 +87,16 @@ class _TestMetrics:
     )
     "Represents the total duration spent executing this test, including reruns."
 
+    @property
+    def rerun_duration(self) -> datetime.timedelta:
+        """
+        Represents the duration of the reruns alone.
+
+        The initial execution runs whether or not flaky detection is enabled, so
+        it is not work this feature added and is not charged to its budget.
+        """
+        return self.total_duration - self.initial_duration
+
     def fill_from_report(self, report: _pytest.reports.TestReport) -> None:
         duration = datetime.timedelta(seconds=report.duration)
 
@@ -486,6 +496,7 @@ class FlakyDetector:
                 test: {
                     "rerun_count": metrics.rerun_count,
                     "total_duration_ms": metrics.total_duration.total_seconds() * 1000,
+                    "rerun_duration_ms": metrics.rerun_duration.total_seconds() * 1000,
                     "initial_setup_duration_ms": metrics.initial_setup_duration.total_seconds()
                     * 1000,
                     "initial_call_duration_ms": metrics.initial_call_duration.total_seconds()
@@ -516,7 +527,7 @@ class FlakyDetector:
 
     def _get_used_budget_duration(self) -> datetime.timedelta:
         return sum(
-            (metrics.total_duration for metrics in self._test_metrics.values()),
+            (metrics.rerun_duration for metrics in self._test_metrics.values()),
             datetime.timedelta(),
         )
 
@@ -624,7 +635,7 @@ def make_report_from_aggregated(
         return result
 
     available_budget_seconds = available_budget_duration_ms / 1000
-    used_budget_ms = sum(m["total_duration_ms"] for m in test_metrics.values())
+    used_budget_ms = sum(m["rerun_duration_ms"] for m in test_metrics.values())
     used_budget_seconds = used_budget_ms / 1000
     if available_budget_seconds > 0:
         result += (
@@ -646,7 +657,7 @@ def make_report_from_aggregated(
             )
             continue
 
-        rerun_duration_seconds = m["total_duration_ms"] / 1000
+        rerun_duration_seconds = m["rerun_duration_ms"] / 1000
         if available_budget_seconds > 0:
             result += (
                 f"{os.linesep}    • '{test}' has been tested {m['rerun_count']} "

--- a/tests/test_flaky_detection.py
+++ b/tests/test_flaky_detection.py
@@ -224,6 +224,7 @@ def test_flaky_detector_to_serializable_metrics() -> None:
 
     assert result["test_metrics"]["test_foo"]["rerun_count"] == 3
     assert result["test_metrics"]["test_foo"]["total_duration_ms"] == 1050.0
+    assert result["test_metrics"]["test_foo"]["rerun_duration_ms"] == 700.0
     assert result["test_metrics"]["test_foo"]["initial_setup_duration_ms"] == 100.0
     assert result["test_metrics"]["test_foo"]["initial_call_duration_ms"] == 200.0
     assert result["test_metrics"]["test_foo"]["initial_teardown_duration_ms"] == 50.0
@@ -276,6 +277,7 @@ def test_make_report_from_aggregated() -> None:
             "test_bar": {
                 "rerun_count": 10,
                 "total_duration_ms": 1000.0,
+                "rerun_duration_ms": 900.0,
                 "initial_setup_duration_ms": 10.0,
                 "initial_call_duration_ms": 80.0,
                 "initial_teardown_duration_ms": 10.0,
@@ -346,3 +348,25 @@ def test_make_report_from_aggregated_no_tests() -> None:
     )
 
     assert "No new tests detected" in report
+
+
+def test_used_budget_counts_reruns_only() -> None:
+    """The initial execution runs with or without flaky detection, so charging it
+    to the budget would shrink every later test's share of it."""
+    detector = InitializedFlakyDetector()
+    detector._context = _make_flaky_detection_context()
+    detector._available_budget_duration = datetime.timedelta(seconds=10)
+    detector._test_metrics = {
+        "test_foo": flaky_detection._TestMetrics(
+            initial_setup_duration=datetime.timedelta(milliseconds=100),
+            initial_call_duration=datetime.timedelta(milliseconds=200),
+            initial_teardown_duration=datetime.timedelta(milliseconds=50),
+            # 350 ms of initial execution, so 700 ms of it is rerun time.
+            total_duration=datetime.timedelta(milliseconds=1050),
+        ),
+    }
+
+    assert detector._get_used_budget_duration() == datetime.timedelta(milliseconds=700)
+    assert detector._get_remaining_budget_duration() == datetime.timedelta(
+        milliseconds=9300
+    )

--- a/tests/test_xdist.py
+++ b/tests/test_xdist.py
@@ -104,6 +104,7 @@ def test_xdist_aggregated_report() -> None:
         "test_new_a": {
             "rerun_count": 10,
             "total_duration_ms": 500.0,
+            "rerun_duration_ms": 450.0,
             "initial_setup_duration_ms": 5.0,
             "initial_call_duration_ms": 40.0,
             "initial_teardown_duration_ms": 5.0,
@@ -114,6 +115,7 @@ def test_xdist_aggregated_report() -> None:
         "test_new_b": {
             "rerun_count": 8,
             "total_duration_ms": 400.0,
+            "rerun_duration_ms": 345.0,
             "initial_setup_duration_ms": 5.0,
             "initial_call_duration_ms": 45.0,
             "initial_teardown_duration_ms": 5.0,


### PR DESCRIPTION
The budget is a fraction of the suite's expected duration — an allowance for the
extra work flaky detection adds. Every report's duration was charged to it,
including the initial execution's setup, call and teardown, which run whether or
not the feature is enabled.

Tests were therefore billed for work the feature did not cause. The budget
drained faster than intended, so tests processed later in the session received
smaller deadlines and fewer reruns than the server allocated, and the terminal
report's "Used X % of the budget" overstated consumption — by the whole initial
execution of every tracked test.

Reruns are now measured as the total minus the initial execution, and the report
reads the same figure. Its per-test line already called the value
`rerun_duration_seconds` while being handed the total, which is the confusion
this makes honest.

Depends-On: #470