### PR TITLE
fix(ci-detection): Stop a provider's own name in CI from aborting the run

### DIFF
--- a/pytest_mergify/utils.py
+++ b/pytest_mergify/utils.py
@@ -43,22 +43,42 @@ class StructuredLog:
         )
 
 
+def is_env_true(env: str) -> bool:
+    """
+    Whether the user turned on a flag this plugin documents as a boolean.
+
+    Anything unrecognised is off, so that a misspelt `true` cannot enable a
+    feature the user never asked for.
+    """
+    try:
+        return strtobool(os.environ.get(env, "").strip())
+    except ValueError:
+        return False
+
+
+def is_env_enabled(env: str) -> bool:
+    """
+    Whether an environment variable marks a provider as the one in use.
+
+    Providers set these to a boolean, to their own name, or to a URL, so
+    anything non-empty that is not a boolean counts as on.
+    """
+    value = os.environ.get(env, "").strip()
+
+    try:
+        return strtobool(value)
+    except ValueError:
+        return bool(value)
+
+
 def is_in_ci() -> bool:
-    return strtobool(os.environ.get("CI", "false")) or strtobool(
-        os.environ.get("PYTEST_MERGIFY_ENABLE", "false")
-    )
+    return is_env_enabled("CI") or is_env_true("PYTEST_MERGIFY_ENABLE")
 
 
 def get_ci_provider() -> typing.Optional[CIProviderT]:
     for envvar, name in SUPPORTED_CIs.items():
-        if envvar in os.environ:
-            try:
-                enabled = strtobool(os.environ[envvar])
-            except ValueError:
-                # Not a boolean, just check it's not empty
-                enabled = bool(os.environ[envvar].strip())
-            if enabled:
-                return name
+        if is_env_enabled(envvar):
+            return name
 
     return None
 
@@ -175,14 +195,3 @@ def git(*args: str) -> typing.Optional[str]:
         ).strip()
     except subprocess.CalledProcessError:
         return None
-
-
-def is_env_truthy(key: str) -> bool:
-    return os.getenv(key, default="").lower() in {
-        "y",
-        "yes",
-        "t",
-        "true",
-        "on",
-        "1",
-    }

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -20,16 +20,32 @@ def test_no_ci(pytester_with_spans: conftest.PytesterWithSpanT) -> None:
     assert all("Mergify" not in line for line in result.stdout.lines)
 
 
-@pytest.mark.parametrize("env", ("PYTEST_MERGIFY_ENABLED", "CI"))
+@pytest.mark.parametrize("env", ("PYTEST_MERGIFY_ENABLE", "CI"))
 def test_enabled(
     env: str,
     pytester_with_spans: conftest.PytesterWithSpanT,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("CI", raising=False)
-    result, spans = pytester_with_spans(setenv={env: "true"})
+    # `CI` is cleared through `setenv` rather than `monkeypatch`, because the
+    # fixture sets it back afterwards -- clearing it earlier leaves both
+    # parameters exercising the same variable.
+    result, spans = pytester_with_spans(setenv={"CI": None, env: "true"})
     assert spans is not None
     assert any("Mergify CI" in line for line in result.stdout.lines)
+
+
+def test_enabled_with_a_provider_name_as_ci(
+    pytester: Pytester,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Woodpecker and Drone set `CI` to their own name. Whatever the plugin makes
+    # of that, deciding it must not take the user's session down with it.
+    monkeypatch.setenv("CI", "woodpecker")
+    monkeypatch.delenv("MERGIFY_TOKEN", raising=False)
+    pytester.makepyfile("def test_pass(): pass")
+
+    result = pytester.runpytest_subprocess()
+
+    result.assert_outcomes(passed=1)
 
 
 def test_empty_token(pytester_with_spans: conftest.PytesterWithSpanT) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pytest_mergify.utils import get_repository_name_from_url
+from pytest_mergify.utils import get_repository_name_from_url, is_in_ci
 
 
 @pytest.mark.parametrize(
@@ -45,3 +45,33 @@ def test_get_repository_name_from_url_invalid(url: str) -> None:
     """Test invalid URL formats that should return None."""
     result = get_repository_name_from_url(url)
     assert result is None
+
+
+@pytest.mark.parametrize(
+    argnames=("value", "expected"),
+    argvalues=[
+        pytest.param("true", True, id="boolean-true"),
+        pytest.param("1", True, id="boolean-one"),
+        pytest.param("false", False, id="boolean-false"),
+        pytest.param("0", False, id="boolean-zero"),
+        # Woodpecker and Drone set `CI` to their own name rather than a boolean.
+        pytest.param("woodpecker", True, id="provider-name"),
+        pytest.param("drone", True, id="other-provider-name"),
+        # A workflow whose `env: CI: ${{ ... }}` resolved to nothing.
+        pytest.param("", False, id="empty"),
+        pytest.param("   ", False, id="blank"),
+        # A YAML block scalar keeps the newline its author did not intend.
+        pytest.param("false ", False, id="boolean-false-with-trailing-space"),
+        pytest.param(" 0", False, id="boolean-zero-with-leading-space"),
+        pytest.param("true\n", True, id="boolean-true-with-newline"),
+    ],
+)
+def test_is_in_ci_accepts_any_value(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+    expected: bool,
+) -> None:
+    monkeypatch.setenv("CI", value)
+    monkeypatch.delenv("PYTEST_MERGIFY_ENABLE", raising=False)
+
+    assert is_in_ci() is expected


### PR DESCRIPTION
Woodpecker and Drone set `CI` to their own name rather than to a boolean, and
`is_in_ci` fed that straight to `strtobool`, which raises. That gate runs from
`pytest_configure`, so the ValueError surfaced as INTERNALERROR and no test ran
at all -- the plugin taking down the session it exists to observe. An empty
value, from a workflow whose `env: CI: ${{ ... }}` resolved to nothing, did the
same.

These variables ask two different questions, so there are two readers.
`is_env_enabled` asks whether one marks a provider as the one in use, and
tolerates a name or a URL exactly as `get_ci_provider` already did -- that
tolerance now lives in one place both callers share. `is_env_true` asks whether
the user turned a documented boolean on, where anything unrecognised has to read
as off.

Both strip first. A YAML block scalar leaves a trailing newline, and `CI="false "`
resolving to on would be a worse outcome than the crash it replaces: the run
would upload results from a machine that had asked to be left alone.

The dead `is_env_truthy` -- a third spelling of the same idea, with no callers
anywhere -- goes with it.

The opt-in test was parametrised on `PYTEST_MERGIFY_ENABLED`, a name no code
reads, and passed only because the fixture restores `CI` after the test clears
it. Both parameters were therefore exercising `CI`, which is why this crash was
never caught.