### PR TITLE
fix(ci-detection): Survive an image that ships no git

### DIFF
--- a/pytest_mergify/utils.py
+++ b/pytest_mergify/utils.py
@@ -193,5 +193,7 @@ def git(*args: str) -> typing.Optional[str]:
             text=True,
             stderr=subprocess.DEVNULL,
         ).strip()
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, OSError):
+        # OSError covers an image that ships no git at all. This runs during
+        # `pytest_configure` on every run, in or out of CI.
         return None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
+import pathlib
+
 import pytest
 
-from pytest_mergify.utils import get_repository_name_from_url, is_in_ci
+from pytest_mergify.utils import get_repository_name_from_url, git, is_in_ci
 
 
 @pytest.mark.parametrize(
@@ -75,3 +77,13 @@ def test_is_in_ci_accepts_any_value(
     monkeypatch.delenv("PYTEST_MERGIFY_ENABLE", raising=False)
 
     assert is_in_ci() is expected
+
+
+def test_git_without_a_git_binary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    # Slim and distroless images ship no git at all.
+    monkeypatch.setenv("PATH", str(tmp_path))
+
+    assert git("config", "--get", "remote.origin.url") is None


### PR DESCRIPTION
`git()` caught `CalledProcessError` but not the `FileNotFoundError` raised when
there is no git binary to run. It is called from `pytest_configure` on every
run, so on a slim or distroless image the plugin aborted the session with
INTERNALERROR before a single test executed -- with no CI variables set and no
Mergify token configured, in a run it had no business touching at all.

Broadened to OSError so a git that is present but unusable -- unreadable, or a
PATH entry that is not a directory -- lands in the same place. Every one of
these means the same thing to the caller: no repository name is available, which
`git()` already models as None.