### PR TITLE
fix(tracing): Ask pytest whether a test is skipped instead of working it out

### DIFF
--- a/pytest_mergify/__init__.py
+++ b/pytest_mergify/__init__.py
@@ -1,17 +1,16 @@
 import datetime
 import os
-import platform
-import sys
 import typing
-from collections.abc import Mapping
 
 import _pytest.config
 import _pytest.config.argparsing
 import _pytest.main
 import _pytest.nodes
+import _pytest.outcomes
 import _pytest.pathlib
 import _pytest.reports
 import _pytest.runner
+import _pytest.skipping
 import _pytest.terminal
 import opentelemetry.trace
 import pytest
@@ -550,45 +549,20 @@ def _call_outcomes(
 
 
 def _should_skip_item(item: _pytest.nodes.Item) -> bool:
-    if item.get_closest_marker("skip") is not None:
-        return True
+    """
+    Whether pytest will skip this item before it gets to run.
 
-    skipif_marker = item.get_closest_marker("skipif")
-    if skipif_marker is None:
+    Asked of pytest rather than worked out here, so that the answer cannot
+    drift from the rules pytest actually applies.
+    """
+    try:
+        return _pytest.skipping.evaluate_skip_marks(item) is not None
+    except (Exception, _pytest.outcomes.OutcomeException):
+        # Setup meets the same mark again and turns it into one clean error on
+        # the test, rather than the end of everyone's session. Outcomes descend
+        # from BaseException, so `Exception` alone would swallow one raised
+        # here -- outside the phase entitled to act on it.
         return False
-
-    condition = skipif_marker.args[0]
-    if not isinstance(condition, str):
-        return bool(condition)
-
-    # Mimics how pytest evaluate the conditions
-    # https://github.com/pytest-dev/pytest/blob/c5a75f2498c86850c4ce13bcf10d56efc92394a4/src/_pytest/skipping.py#L88
-    globals_ = {
-        "os": os,
-        "sys": sys,
-        "platform": platform,
-        "config": item.config,
-    }
-    if hasattr(item, "ihook"):
-        for dictionary in reversed(
-            item.ihook.pytest_markeval_namespace(config=item.config)
-        ):
-            if not isinstance(dictionary, Mapping):
-                raise ValueError(
-                    f"pytest_markeval_namespace() needs to return a dict, got {dictionary!r}"
-                )
-            globals_.update(dictionary)
-    if hasattr(item, "obj"):
-        globals_.update(item.obj.__globals__)
-
-    condition_code = compile(
-        source=condition,
-        filename=f"<{skipif_marker.name} condition>",
-        mode="eval",
-    )
-
-    # nosemgrep: python.lang.security.audit.eval-detected.eval-detected
-    return bool(eval(condition_code, globals_))
 
 
 def _write_flaky_detector_error(

--- a/tests/test_spans.py
+++ b/tests/test_spans.py
@@ -170,6 +170,8 @@ def test_skipped():
         "skipif(1 + 1, reason='with eval')",
         "skipif('1 + 1', reason='as str')",
         "skipif('sys.version_info.major > 1', reason='not needed')",
+        "skipif(condition=True, reason='as kwarg')",
+        "skipif(reason='unconditional')",
     ],
 )
 def test_mark_skipped(
@@ -206,6 +208,78 @@ def test_skipped():
         spans["test_mark_skipped.py::test_skipped"].parent.span_id
         == session_span.context.span_id
     )
+
+
+def test_mark_skipped_by_an_outer_mark(
+    pytester_with_spans: conftest.PytesterWithSpanT,
+) -> None:
+    # The mark nearest the test does not decide the outcome on its own: pytest
+    # skips as soon as any skipif mark matches.
+    result, spans = pytester_with_spans("""
+import pytest
+pytestmark = pytest.mark.skipif(True, reason='whole module')
+
+@pytest.mark.skipif(False, reason='but not this one')
+def test_skipped():
+    assert False
+""")
+    result.assert_outcomes(skipped=1)
+    assert spans is not None
+    assert spans["test_mark_skipped_by_an_outer_mark.py::test_skipped"].attributes == {
+        "test.case.result.status": "skipped",
+        "test.scope": "case",
+        "code.function": "test_skipped",
+        "code.lineno": 3,
+        "code.filepath": "test_mark_skipped_by_an_outer_mark.py",
+        "code.namespace": "",
+        "code.file.path": anys.ANY_STR,
+        "code.line.number": 3,
+        "cicd.test.quarantined": False,
+    }
+
+
+def test_mark_skipped_by_a_later_condition(
+    pytester_with_spans: conftest.PytesterWithSpanT,
+) -> None:
+    # `skipif` accepts several conditions and skips as soon as one of them
+    # holds, so reading only the first would report this test as executed.
+    result, spans = pytester_with_spans("""
+import pytest
+@pytest.mark.skipif(False, True, reason='the second one')
+def test_skipped():
+    assert False
+""")
+    result.assert_outcomes(skipped=1)
+    assert spans is not None
+    assert spans[
+        "test_mark_skipped_by_a_later_condition.py::test_skipped"
+    ].attributes == {
+        "test.case.result.status": "skipped",
+        "test.scope": "case",
+        "code.function": "test_skipped",
+        "code.lineno": 1,
+        "code.filepath": "test_mark_skipped_by_a_later_condition.py",
+        "code.namespace": "",
+        "code.file.path": anys.ANY_STR,
+        "code.line.number": 1,
+        "cicd.test.quarantined": False,
+    }
+
+
+def test_mark_skipped_with_an_unresolvable_condition(
+    pytester_with_spans: conftest.PytesterWithSpanT,
+) -> None:
+    # pytest turns a condition it cannot evaluate into one clean error on the
+    # test. Reading the same mark to build a span must not turn it into the end
+    # of the session.
+    result, _ = pytester_with_spans("""
+import pytest
+@pytest.mark.skipif('undefined_symbol_xyz', reason='broken')
+def test_broken():
+    pass
+""")
+    assert "INTERNALERROR" not in result.stdout.str()
+    result.assert_outcomes(errors=1)
 
 
 def test_mark_not_skipped(


### PR DESCRIPTION
`_should_skip_item` re-derived the answer from `get_closest_marker("skipif")`
and `args[0]`, and had drifted from the rules it was copying. Three shapes
pytest documents took the session down with INTERNALERROR before any test ran:
`skipif(condition=...)`, a bare `skipif(reason=...)`, and a string condition
naming something undefined. It runs for every item whenever tracing is on, so
none of this needed quarantine to be configured.

It was also wrong where it did not crash. Only the nearest mark was read, so a
test skipped by its module or class was not recognised as skipped and its span
went up with no `test.case.result.status` at all -- vanishing from the result
counts rather than arriving as a skip. Reading only `args[0]` lost the same
answer for `skipif(False, True, reason=...)`, where pytest skips on any one of
several conditions.

`evaluate_skip_marks` is the function being imitated, so call it. It walks every
mark, accepts each spelling of the condition, and evaluates strings in the
namespace plugins contribute through `pytest_markeval_namespace`.

The answer is wanted while building a span, which is not the phase that owns it,
so a mark pytest rejects must not escape from here -- it raises again in setup,
where it lands as one clean error on one test. `OutcomeException` is caught by
name because it descends from BaseException precisely so that `except Exception`
cannot absorb an outcome by accident.

The cost is that each condition is now evaluated twice, once here and once in
setup. That is accepted: string conditions are `eval`ed against a namespace, so
a condition with side effects would already be unsound under pytest's own
`--collect-only`, and the alternative is keeping a copy of rules that has
already been shown to drift.