### PR TITLE
fix(quarantine): Contain a malformed quarantine payload

### DIFF
--- a/pytest_mergify/quarantine.py
+++ b/pytest_mergify/quarantine.py
@@ -70,13 +70,31 @@ class Quarantine:
                 self.init_error_msg = f"Error when querying Mergify's API, tests won't be quarantined. Error: {str(exc)}"
                 return
 
-            quarantined_tests.extend(
-                qtest["test_name"]
-                for qtest in quarantine_resp.json()["quarantined_tests"]
-            )
+            try:
+                quarantined_tests.extend(
+                    qtest["test_name"]
+                    for qtest in quarantine_resp.json()["quarantined_tests"]
+                )
+            except (
+                # `requests` only grew its own `JSONDecodeError` in 2.27, and
+                # this package accepts anything from 2 up. Naming it here would
+                # raise `AttributeError` out of the `except` itself on an older
+                # one, which is the crash this guard exists to prevent. The
+                # subclass is caught either way.
+                ValueError,
+                KeyError,
+                # A payload that is valid JSON but not an object (list, string,
+                # number...) raises TypeError on subscript access.
+                TypeError,
+            ) as exc:
+                self.init_error_msg = f"Unexpected response from Mergify's API, tests won't be quarantined. Error: {str(exc)}"
+                return
 
+            # Left unguarded: `requests` parses the `Link` header leniently and
+            # gives every entry it returns a `url`, whatever the header said.
             next_link = quarantine_resp.links.get("next")
             url = next_link["url"] if next_link else None
+
             params = None
 
         self.quarantined_tests = quarantined_tests

--- a/tests/test_quarantine.py
+++ b/tests/test_quarantine.py
@@ -1,3 +1,5 @@
+import typing
+
 import pytest
 import responses
 import requests
@@ -116,6 +118,49 @@ def test_quarantine_resets_on_mid_pagination_error() -> None:
     assert q.init_error_msg is not None
     assert "Error when querying Mergify's API" in q.init_error_msg
     # No partial population: a failure on page 2 must not leak page 1's data.
+    assert q.quarantined_tests == []
+
+
+@pytest.mark.parametrize(
+    argnames="response_kwargs",
+    argvalues=[
+        pytest.param(
+            {"body": "<html>502 Bad Gateway</html>", "content_type": "text/html"},
+            id="an-error-page-served-as-200",
+        ),
+        pytest.param({"json": {"items": []}}, id="a-renamed-collection"),
+        pytest.param(
+            {"json": {"quarantined_tests": [{"name": "test_a"}]}},
+            id="a-renamed-entry-field",
+        ),
+        pytest.param({"json": []}, id="a-payload-that-is-not-an-object"),
+    ],
+)
+@responses.activate
+def test_quarantine_handles_a_malformed_payload(
+    response_kwargs: typing.Dict[str, typing.Any],
+) -> None:
+    # A proxy, WAF or CDN can answer 200 with its own error page, and the API's
+    # schema can move under us. Neither is the user's problem to debug from a
+    # session that refused to start.
+    responses.add(
+        responses.GET,
+        "https://example.com/v1/ci/owner/repositories/repo/quarantines",
+        status=200,
+        **response_kwargs,
+    )
+
+    q = Quarantine(
+        api_url="https://example.com",
+        token="tok",
+        repo_name="owner/repo",
+        branch_name="main",
+    )
+
+    assert q.init_error_msg is not None
+    # Names the payload path: the transport and status handlers beside it end
+    # their messages the same way, so a weaker match passes on either of them.
+    assert "Unexpected response" in q.init_error_msg
     assert q.quarantined_tests == []
 
 


### PR DESCRIPTION
The response body was read with no guard at all: `.json()`, the
`quarantined_tests` key and each entry's `test_name` were all dereferenced
outside every `try`. A proxy, WAF or CDN answering 200 with its own HTML error
page, or one renamed field on the API side, therefore ended the session with
INTERNALERROR before collection -- for every customer with quarantine enabled at
once, since the trigger is the response rather than anything in their
repository.

Reading a list of quarantined tests is not worth a user's run. It now fails open
the way the transport errors beside it already do.

The `next` link is deliberately left outside that guard. `requests` parses the
`Link` header leniently and gives every entry it returns a `url`, so the lookup
raises nothing to catch however malformed the header is -- a guard around it
would only claim a protection it cannot provide.

The set of exceptions, and the note about subscripting a non-object, follow
`TestSelection.__post_init__`, which has handled exactly these since it was
written. It catches `ValueError` rather than that one's
`requests.exceptions.JSONDecodeError`, which `requests` only added in 2.27 while
this package accepts anything from 2 up: naming it raises `AttributeError` out
of the `except` itself on an older one, turning the guard into the crash it was
added to prevent.