### PR TITLE
fix(test-selection): Check the served subset is a list of node ids

### DIFF
--- a/pytest_mergify/test_selection.py
+++ b/pytest_mergify/test_selection.py
@@ -75,12 +75,30 @@ class TestSelection:
             # a subset with no `tests` is a real protocol break worth surfacing,
             # which a blanket `.get("tests", [])` would silently run past.
             tests = payload["tests"] if selection == "subset" else []
+            # The subset is not read again until `pytest_collection_modifyitems`,
+            # a hook that runs long after this -- the last point at which a
+            # problem with it can still be reported. Hence checked here rather
+            # than discovered there.
+            if not isinstance(tests, list) or not all(
+                isinstance(test, str) for test in tests
+            ):
+                # Truncated: the whole subset reaches five figures of characters
+                # on a large suite, and this ends up in a terminal warning.
+                raise TypeError(
+                    f"'tests' must be a list of node ids, got {tests!r:.200}"
+                )
         except (
             requests.HTTPError,
-            requests.exceptions.JSONDecodeError,
+            # `requests` only grew its own `JSONDecodeError` in 2.27, and this
+            # package accepts anything from 2 up. Naming it here would raise
+            # `AttributeError` out of the `except` itself on an older one, which
+            # is the crash this guard exists to prevent. The subclass is caught
+            # either way.
+            ValueError,
             KeyError,
-            # A payload that is valid JSON but not an object (list, string,
-            # number...) raises TypeError on subscript access.
+            # Raised above for a subset that is not a list of node ids, and by
+            # subscripting a payload that is valid JSON but not an object (list,
+            # string, number...).
             TypeError,
         ) as exc:
             self.init_error_msg = f"Error when querying Mergify's API, the full test suite will run. Error: {str(exc)}"

--- a/tests/test_test_selection.py
+++ b/tests/test_test_selection.py
@@ -1,6 +1,7 @@
 import dataclasses
 import typing
 
+import pytest
 import responses
 
 from pytest_mergify import test_selection
@@ -38,6 +39,38 @@ class FakeHook:
 @dataclasses.dataclass
 class FakeConfig:
     hook: FakeHook = dataclasses.field(default_factory=FakeHook)
+
+
+@pytest.mark.parametrize(
+    argnames="tests",
+    argvalues=[
+        pytest.param(5, id="a-number"),
+        pytest.param("tests/a.py::test_one", id="a-bare-string"),
+        pytest.param({"tests/a.py::test_one": True}, id="an-object"),
+        pytest.param([{"nodeid": "tests/a.py::test_one"}], id="a-list-of-objects"),
+    ],
+)
+@responses.activate
+def test_a_malformed_tests_value_runs_the_full_suite(tests: typing.Any) -> None:
+    # This shape comes from the server, so getting it wrong reaches every
+    # opted-in repository at once rather than one misconfigured user.
+    responses.add(
+        responses.GET,
+        ENDPOINT,
+        json={"selection": "subset", "reason": "reduced_rerun", "tests": tests},
+    )
+
+    selection = _make_selection()
+
+    assert selection.selection == "full"
+    assert selection.init_error_msg is not None
+
+    # Applying the answer happens in a hook, past everything that could report a
+    # problem, so it has to survive whatever got stored.
+    items = [FakeItem("tests/a.py::test_one"), FakeItem("tests/b.py::test_two")]
+    selection.filter_items(FakeConfig(), items)  # type: ignore[arg-type]
+
+    assert len(items) == 2
 
 
 @responses.activate


### PR DESCRIPTION
`tests` was taken from the payload and stored on the strength of being truthy.
The value is not touched again until `pytest_collection_modifyitems` calls
`set(self.tests)`, which is a hook -- past `__post_init__`, past its `try`, past
anything able to report a problem. A number or a list of objects therefore
raised TypeError from inside collection: INTERNALERROR, no tests run, exit 3.

This shape comes from the server rather than from the user's configuration, so a
single bad engine deploy would reach every opted-in repository at once, and the
run it breaks is a merge-queue retry.

Values that do not crash are rejected too, because they are wrong more quietly:
a bare string decays to a set of characters and a mapping to a set of keys,
neither of which matches a node id, so the run silently falls back to the full
suite and reports the reason as a subset that matched nothing.

The TypeError is raised where the existing handler can see it, so a bad payload
takes the path bad payloads already take -- the full suite runs, and the summary
says why. The rejected value is truncated on the way into that message: a subset
for a large suite runs to five figures of characters, and this one measured
13130 against a 200-character cap.

That handler also stops naming `requests.exceptions.JSONDecodeError`, which
`requests` only added in 2.27 while this package accepts anything from 2 up.
On an older one the name raises `AttributeError` out of the `except` itself,
so the guard became the crash for exactly the malformed payloads it was meant
to absorb. `ValueError`, which it subclasses, holds on every supported version.