### PR TITLE
fix(tracing): Stop the span processor discarding a run it never uploaded

### DIFF
--- a/pytest_mergify/__init__.py
+++ b/pytest_mergify/__init__.py
@@ -158,16 +158,22 @@ class PytestMergify:
             )
         else:
             try:
-                self.mergify_ci.tracer_provider.force_flush()
+                exported = self.mergify_ci.tracer_provider.force_flush()
             except Exception as e:
                 terminalreporter.write_line(
                     f"Error while exporting traces: {e}",
                     red=True,
                 )
             else:
-                terminalreporter.write_line(
-                    f"MERGIFY_TEST_RUN_ID={self.mergify_ci.test_run_id}",
-                )
+                if exported:
+                    terminalreporter.write_line(
+                        f"MERGIFY_TEST_RUN_ID={self.mergify_ci.test_run_id}",
+                    )
+                else:
+                    terminalreporter.write_line(
+                        "Mergify's API did not accept the test results after retrying; they were not uploaded",
+                        red=True,
+                    )
 
             try:
                 self.mergify_ci.tracer_provider.shutdown()

--- a/pytest_mergify/ci_insights.py
+++ b/pytest_mergify/ci_insights.py
@@ -31,15 +31,33 @@ class SynchronousBatchSpanProcessor(export.SimpleSpanProcessor):
         self.queue: typing.List[ReadableSpan] = []
 
     def force_flush(self, timeout_millis: int = 30_000) -> bool:
-        self.span_exporter.export(self.queue)
-        self.queue.clear()
-        return True
+        if not self.queue:
+            return True
+
+        try:
+            exported = self.span_exporter.export(self.queue)
+        finally:
+            # Cleared even when the export raises, so a batch is attempted once.
+            # `shutdown` flushes too, and the SDK keeps its atexit hook armed
+            # until that returns, so a queue left behind is sent twice more and
+            # the last failure surfaces as an ignored exception at exit.
+            self.queue.clear()
+
+        return exported is export.SpanExportResult.SUCCESS
 
     def on_end(self, span: ReadableSpan) -> None:
         if not span.context.trace_flags.sampled:
             return
 
         self.queue.append(span)
+
+    def shutdown(self) -> None:
+        # The SDK registers this with atexit, so it is what runs for a session
+        # that ends without reaching the terminal summary -- a job timeout, an
+        # OOM kill, another plugin raising early. Inherited unchanged it closes
+        # the exporter and drops everything still queued, which is the whole run.
+        self.force_flush()
+        super().shutdown()
 
 
 class SessionHardRaiser(requests.Session):  # type: ignore[misc]

--- a/tests/test_ci_insights.py
+++ b/tests/test_ci_insights.py
@@ -7,10 +7,74 @@ import _pytest.pytester
 import _pytest.reports
 import pytest
 import responses
+from opentelemetry.sdk.trace import TracerProvider, export
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
 
 import pytest_mergify
 from pytest_mergify import ci_insights
 from tests import conftest
+
+
+class _FailingSpanExporter(export.SpanExporter):
+    def export(self, spans: typing.Any) -> export.SpanExportResult:
+        return export.SpanExportResult.FAILURE
+
+
+def _record_one_span(processor: ci_insights.SynchronousBatchSpanProcessor) -> None:
+    provider = TracerProvider()
+    provider.add_span_processor(processor)
+    with provider.get_tracer("tests").start_as_current_span("a-span"):
+        pass
+
+
+def test_queued_spans_are_exported_on_shutdown() -> None:
+    # The SDK registers `shutdown` with atexit, so it is the only thing that
+    # runs when a session dies without reaching the terminal summary.
+    exporter = InMemorySpanExporter()
+    processor = ci_insights.SynchronousBatchSpanProcessor(exporter)
+
+    _record_one_span(processor)
+    assert exporter.get_finished_spans() == ()
+
+    processor.shutdown()
+
+    assert len(exporter.get_finished_spans()) == 1
+
+
+def test_flushing_reports_whether_the_export_worked() -> None:
+    processor = ci_insights.SynchronousBatchSpanProcessor(_FailingSpanExporter())
+    _record_one_span(processor)
+
+    assert processor.force_flush() is False
+
+
+def test_flushing_an_empty_queue_reports_success() -> None:
+    processor = ci_insights.SynchronousBatchSpanProcessor(InMemorySpanExporter())
+
+    assert processor.force_flush() is True
+
+
+def test_a_batch_the_exporter_rejects_is_attempted_once() -> None:
+    # `shutdown` flushes as well, and the SDK leaves its atexit hook armed until
+    # that returns, so a batch left in the queue is sent three times over and
+    # the last failure lands as an ignored exception at interpreter exit.
+    attempts = []
+
+    class _RaisingSpanExporter(export.SpanExporter):
+        def export(self, spans: typing.Any) -> export.SpanExportResult:
+            attempts.append(len(spans))
+            raise RuntimeError("the API rejected the batch")
+
+    processor = ci_insights.SynchronousBatchSpanProcessor(_RaisingSpanExporter())
+    _record_one_span(processor)
+
+    with pytest.raises(RuntimeError):
+        processor.force_flush()
+    processor.shutdown()
+
+    assert attempts == [1]
 
 
 def _set_test_environment(


### PR DESCRIPTION
Two ways the queue went missing without anyone being told.

`shutdown` was inherited from `SimpleSpanProcessor`, which closes the exporter
and leaves the queue where it is. The SDK registers exactly that method with
atexit, so its one safety net was wired to the call that drops the data: a job
timeout, an OOM kill, or another plugin raising before the terminal summary took
the whole run with it.

`force_flush` then ignored what `export` returned and answered True regardless,
so a rejected batch still printed `MERGIFY_TEST_RUN_ID=` and the run looked
uploaded. The summary now says plainly when nothing arrived, which is the point
of the line -- an id naming a run Mergify never received is worse than no id.

Flushing an empty queue short-circuits, so the flush now on the shutdown path
costs no second request after the terminal summary has already sent everything.