### PR TITLE
fix(tracing): Let the exporter retry a transient upload failure

### DIFF
--- a/pytest_mergify/ci_insights.py
+++ b/pytest_mergify/ci_insights.py
@@ -60,12 +60,20 @@ class SynchronousBatchSpanProcessor(export.SimpleSpanProcessor):
         super().shutdown()
 
 
-class SessionHardRaiser(requests.Session):  # type: ignore[misc]
-    """Custom requests.Session that raises an exception on HTTP error."""
+class SessionRaisingOnPermanentError(requests.Session):  # type: ignore[misc]
+    """A requests.Session that raises on an error retrying cannot resolve."""
 
     def request(self, *args: typing.Any, **kwargs: typing.Any) -> requests.Response:
         response = super().request(*args, **kwargs)
-        response.raise_for_status()
+
+        # A client error reads the same however many times it is sent, so it is
+        # raised here, where the summary can name it. Anything the OTLP exporter
+        # treats as retryable -- 408 and 5xx, as of 1.30 -- is handed back
+        # untouched, because raising ahead of it lost a whole run's spans to a
+        # blip that one retry would have cleared.
+        if 400 <= response.status_code < 500 and response.status_code != 408:
+            response.raise_for_status()
+
         return response
 
 
@@ -145,7 +153,7 @@ class MergifyCIInsights:
             except utils.InvalidRepositoryFullNameError:
                 return
             self.exporter = OTLPSpanExporter(
-                session=SessionHardRaiser(),
+                session=SessionRaisingOnPermanentError(),
                 endpoint=f"{self.api_url}/v1/ci/{owner}/repositories/{repo}/traces",
                 headers={"Authorization": f"Bearer {self.token}"},
                 compression=Compression.Gzip,

--- a/tests/test_ci_insights.py
+++ b/tests/test_ci_insights.py
@@ -6,6 +6,7 @@ import _pytest.nodes
 import _pytest.pytester
 import _pytest.reports
 import pytest
+import requests
 import responses
 from opentelemetry.sdk.trace import TracerProvider, export
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
@@ -75,6 +76,43 @@ def test_a_batch_the_exporter_rejects_is_attempted_once() -> None:
     processor.shutdown()
 
     assert attempts == [1]
+
+
+@pytest.mark.parametrize(
+    argnames="status",
+    argvalues=[
+        pytest.param(408, id="request-timeout"),
+        pytest.param(500, id="internal-server-error"),
+        pytest.param(502, id="bad-gateway"),
+        pytest.param(503, id="service-unavailable"),
+    ],
+)
+@responses.activate
+def test_a_transient_error_is_left_to_the_exporter(status: int) -> None:
+    responses.add(responses.POST, "https://example.com/traces", status=status)
+
+    response = ci_insights.SessionRaisingOnPermanentError().post(
+        "https://example.com/traces"
+    )
+
+    assert response.status_code == status
+
+
+@pytest.mark.parametrize(
+    argnames="status",
+    argvalues=[
+        pytest.param(400, id="bad-request"),
+        pytest.param(401, id="unauthorized"),
+        pytest.param(403, id="forbidden"),
+        pytest.param(404, id="not-found"),
+    ],
+)
+@responses.activate
+def test_a_permanent_error_is_surfaced_immediately(status: int) -> None:
+    responses.add(responses.POST, "https://example.com/traces", status=status)
+
+    with pytest.raises(requests.HTTPError):
+        ci_insights.SessionRaisingOnPermanentError().post("https://example.com/traces")
 
 
 def _set_test_environment(


### PR DESCRIPTION
The session called `raise_for_status` on every response, and that happens inside
the OTLP exporter's own request. The exporter never got to look at the status,
so its retry and backoff were unreachable, and the exception unwound through a
flush whose result nothing checked: one 502 from a proxy restart lost every span
in the run while the session still exited 0 and CI stayed green.

Only permanent client errors are raised now. A bad token reads the same on the
tenth attempt as on the first and belongs in the summary immediately; 5xx and
408 go back untouched so the exporter can do what it was written to do. The
class is renamed for the half it kept.

Worth knowing before this merges: a sustained outage now costs the exporter's
full backoff at the end of the run, where it used to give up at once. Measured
at 63.05 s of sleeps over 6 attempts -- 1+2+4+8+16+32, stopping once the delay
reaches the 64 s cap -- and each attempt can add its own 10 s request timeout,
so a server that accepts and then stalls reaches about two minutes. The run's
outcome does not change, only how long the summary takes to admit defeat.

That budget is not bounded by the caller: `force_flush` still ignores its
`timeout_millis` argument. Left alone here, because honouring it means giving
the exporter a deadline rather than patching the processor.

Depends-On: #479