### PR TITLE
fix(tracing): Stop PYTEST_MERGIFY_DEBUG=false from enabling debug

### DIFF
--- a/pytest_mergify/ci_insights.py
+++ b/pytest_mergify/ci_insights.py
@@ -137,10 +137,10 @@ class MergifyCIInsights:
 
         span_processor: SpanProcessor
 
-        if os.environ.get("PYTEST_MERGIFY_DEBUG"):
+        if utils.is_env_true("PYTEST_MERGIFY_DEBUG"):
             self.exporter = export.ConsoleSpanExporter()
             span_processor = SynchronousBatchSpanProcessor(self.exporter)
-        elif utils.strtobool(os.environ.get("_PYTEST_MERGIFY_TEST", "false")):
+        elif utils.is_env_true("_PYTEST_MERGIFY_TEST"):
             from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
                 InMemorySpanExporter,
             )

--- a/pytest_mergify/flaky_detection.py
+++ b/pytest_mergify/flaky_detection.py
@@ -677,7 +677,7 @@ def make_report_from_aggregated(
             f"Reference: https://github.com/pytest-dev/pytest-timeout?tab=readme-ov-file#avoiding-timeouts-in-fixtures"
         )
 
-    if os.environ.get("PYTEST_MERGIFY_DEBUG") and debug_logs:
+    if utils.is_env_true("PYTEST_MERGIFY_DEBUG") and debug_logs:
         result += f"{os.linesep}🔎 Debug Logs"
         for log in debug_logs:
             result += f"{os.linesep}{json.dumps(log)}"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -37,8 +37,7 @@ def test_enabled_with_a_provider_name_as_ci(
     pytester: Pytester,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Woodpecker and Drone set `CI` to their own name. Whatever the plugin makes
-    # of that, deciding it must not take the user's session down with it.
+    # Woodpecker and Drone set `CI` to their own name rather than to a boolean.
     monkeypatch.setenv("CI", "woodpecker")
     monkeypatch.delenv("MERGIFY_TOKEN", raising=False)
     pytester.makepyfile("def test_pass(): pass")
@@ -46,6 +45,29 @@ def test_enabled_with_a_provider_name_as_ci(
     result = pytester.runpytest_subprocess()
 
     result.assert_outcomes(passed=1)
+
+
+@pytest.mark.parametrize(
+    argnames="value",
+    argvalues=[
+        pytest.param("false", id="the-documented-default"),
+        pytest.param("0", id="zero"),
+        pytest.param("no", id="no"),
+        pytest.param("off", id="off"),
+        pytest.param("", id="empty"),
+        pytest.param("false ", id="trailing-space"),
+        pytest.param("treu", id="a-misspelt-true"),
+    ],
+)
+def test_debug_stays_off_for_a_falsy_value(
+    value: str,
+    pytester_with_spans: conftest.PytesterWithSpanT,
+) -> None:
+    # Turning debug on stops results being uploaded, so only a value that
+    # genuinely reads as true may do it.
+    result, spans = pytester_with_spans(setenv={"PYTEST_MERGIFY_DEBUG": value})
+
+    assert spans is not None
 
 
 def test_empty_token(pytester_with_spans: conftest.PytesterWithSpanT) -> None:


### PR DESCRIPTION
The variable was read for truthiness, so any value at all selected the console
exporter -- including `false`, which the README names as its default and so is
the value a user is most likely to write. Nothing then reached Mergify, while
the summary still printed `MERGIFY_TEST_RUN_ID=` and looked like a normal run.

Both readers move across, not just the exporter switch: the flaky detection
report kept its own copy, so `PYTEST_MERGIFY_DEBUG=false` still dumped debug
logs into the summary. Reading it strictly also covers a misspelt `true`, which
previously enabled debug and stopped every upload without saying so.

`_PYTEST_MERGIFY_TEST` on the next line had the opposite problem: it went
through a bare `strtobool`, so a value that is neither boolean nor empty ended
the session from `pytest_configure`.

Depends-On: #475