### PR TITLE
test: Capture what the plugin actually uploads

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
+import dataclasses
 import datetime
+import gzip
 import http.server
 import os
 import re
@@ -6,6 +8,10 @@ import socketserver
 import threading
 import typing
 import uuid
+
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceRequest,
+)
 
 import _pytest.pytester
 import pytest
@@ -147,6 +153,142 @@ class TestHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
     def log_message(self, format: str, *args: object) -> None:
         # Override to suppress console logging during tests.
         pass
+
+
+def _decode_any_value(value: typing.Any) -> typing.Any:
+    kind = value.WhichOneof("value")
+    if kind is None:
+        return None
+
+    if kind == "array_value":
+        return [_decode_any_value(item) for item in value.array_value.values]
+
+    return getattr(value, kind)
+
+
+def _decode_attributes(key_values: typing.Any) -> typing.Dict[str, typing.Any]:
+    return {kv.key: _decode_any_value(kv.value) for kv in key_values}
+
+
+@dataclasses.dataclass
+class UploadedSpan:
+    name: str
+    attributes: typing.Dict[str, typing.Any]
+
+
+@dataclasses.dataclass
+class UploadedBatch:
+    """
+    One resource's spans, as they arrived over the wire.
+
+    A request carries a batch per resource it saw, so counting these counts
+    resources rather than requests -- which for this plugin, holding one
+    provider for the whole session, comes to one per request.
+    """
+
+    resource_attributes: typing.Dict[str, typing.Any]
+    spans: typing.List[UploadedSpan]
+
+    def span(self, name: str) -> UploadedSpan:
+        """
+        The one span with this name.
+
+        A list rather than a dict keyed by name, because names repeat: a rerun
+        of a flaky test uploads the same node id again. Unpacking raises here
+        instead of letting the second copy overwrite the first unseen.
+        """
+        (span,) = [span for span in self.spans if span.name == name]
+        return span
+
+
+class _OTLPServer(socketserver.TCPServer):
+    allow_reuse_address = True
+
+    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        self.bodies: typing.List[bytes] = []
+        super().__init__(*args, **kwargs)
+
+
+class _OTLPRequestHandler(http.server.BaseHTTPRequestHandler):
+    server: _OTLPServer
+
+    def do_POST(self) -> None:
+        body = self.rfile.read(int(self.headers.get("Content-Length") or 0))
+        if self.headers.get("Content-Encoding") == "gzip":
+            body = gzip.decompress(body)
+        self.server.bodies.append(body)
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/x-protobuf")
+        self.end_headers()
+
+    def do_GET(self) -> None:
+        # Quarantine and test selection share this base URL. Answering 404 keeps
+        # them out of the way without pretending they were served.
+        self.send_response(404)
+        self.end_headers()
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+@dataclasses.dataclass
+class OTLPCollector:
+    """
+    What the plugin actually put on the wire.
+
+    The in-memory exporter reaches into the plugin's own process, which cannot
+    see a batch that was never sent, a process other than this one, or a run
+    that ended without a terminal summary. This can.
+    """
+
+    url: str
+    _server: _OTLPServer
+
+    @property
+    def batches(self) -> typing.List[UploadedBatch]:
+        batches = []
+
+        for body in self._server.bodies:
+            request = ExportTraceServiceRequest()
+            request.ParseFromString(body)
+
+            for resource_spans in request.resource_spans:
+                spans = [
+                    UploadedSpan(
+                        name=span.name,
+                        attributes=_decode_attributes(span.attributes),
+                    )
+                    for scope_spans in resource_spans.scope_spans
+                    for span in scope_spans.spans
+                ]
+                batches.append(
+                    UploadedBatch(
+                        resource_attributes=_decode_attributes(
+                            resource_spans.resource.attributes
+                        ),
+                        spans=spans,
+                    )
+                )
+
+        return batches
+
+    @property
+    def span_names(self) -> typing.Set[str]:
+        return {span.name for batch in self.batches for span in batch.spans}
+
+
+@pytest.fixture
+def otlp_collector() -> typing.Generator[OTLPCollector, None, None]:
+    with _OTLPServer(("127.0.0.1", 0), _OTLPRequestHandler) as httpd:
+        host, port = httpd.server_address[0], httpd.server_address[1]
+        thread = threading.Thread(target=httpd.serve_forever)
+        thread.daemon = True
+        thread.start()
+
+        yield OTLPCollector(url=f"http://{host!s}:{port}", _server=httpd)
+
+        httpd.shutdown()
 
 
 @pytest.fixture

--- a/tests/test_uploaded_spans.py
+++ b/tests/test_uploaded_spans.py
@@ -1,0 +1,68 @@
+import re
+
+import _pytest.pytester
+import pytest
+
+from tests import conftest
+
+
+def _configure_upload(
+    monkeypatch: pytest.MonkeyPatch,
+    collector: conftest.OTLPCollector,
+) -> None:
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "Mergifyio/pytest-mergify")
+    monkeypatch.setenv("MERGIFY_TOKEN", "token")
+    monkeypatch.setenv("MERGIFY_API_URL", collector.url)
+    # Both of these swap the exporter for one that uploads nothing.
+    monkeypatch.delenv("_PYTEST_MERGIFY_TEST", raising=False)
+    monkeypatch.delenv("PYTEST_MERGIFY_DEBUG", raising=False)
+
+
+def test_a_run_uploads_its_spans(
+    pytester: _pytest.pytester.Pytester,
+    monkeypatch: pytest.MonkeyPatch,
+    otlp_collector: conftest.OTLPCollector,
+) -> None:
+    _configure_upload(monkeypatch, otlp_collector)
+    pytester.makepyfile("def test_pass(): pass")
+
+    result = pytester.runpytest_subprocess()
+
+    result.assert_outcomes(passed=1)
+    assert len(otlp_collector.batches) == 1
+    assert otlp_collector.span_names == {
+        "pytest session start",
+        "test_a_run_uploads_its_spans.py::test_pass",
+    }
+
+
+def test_an_uploaded_span_carries_its_attributes(
+    pytester: _pytest.pytester.Pytester,
+    monkeypatch: pytest.MonkeyPatch,
+    otlp_collector: conftest.OTLPCollector,
+) -> None:
+    # Asserting on the decoded payload rather than on terminal text: a run can
+    # print a run id and still have uploaded nothing.
+    _configure_upload(monkeypatch, otlp_collector)
+    pytester.makepyfile("def test_pass(): pass")
+
+    result = pytester.runpytest_subprocess()
+
+    # Asserted before the payload, so a run that died on the way to uploading
+    # reads as the failure it is rather than as a missing key.
+    result.assert_outcomes(passed=1)
+    (batch,) = otlp_collector.batches
+    span = batch.span("test_an_uploaded_span_carries_its_attributes.py::test_pass")
+
+    assert span.attributes["test.case.result.status"] == "passed"
+    assert span.attributes["test.scope"] == "case"
+    assert (
+        batch.resource_attributes["vcs.repository.name"] == "Mergifyio/pytest-mergify"
+    )
+    # The id the run reported to the user has to be the one it filed the spans
+    # under, or the summary sends them looking up somebody else's run.
+    printed_run_id = re.search(r"MERGIFY_TEST_RUN_ID=(\w+)", result.stdout.str())
+    assert printed_run_id is not None
+    assert batch.resource_attributes["test.run.id"] == printed_run_id.group(1)


### PR DESCRIPTION
Every span assertion in the suite reads `plugin.mergify_ci.exporter`, an
attribute of the plugin object living in this process. That forces the in-memory
exporter and `runpytest_inprocess`, so nothing can be asserted about a batch that
was never sent, a run that ended before the terminal summary, or a process other
than this one. Three tests do reach the real exporter, and all three assert only
on terminal text -- so no test has ever looked at a span Mergify would receive.

This adds an endpoint that keeps the request bodies and decodes the protobuf, and
drives the plugin through `runpytest_subprocess` against it. Assertions are on
resource attributes and span attributes as they arrive on the wire, including
that the run id printed for the user is the one the spans were filed under.

Spans are held as a list rather than a dict keyed by name, because names repeat:
a rerun of a flaky test uploads the same node id again, and a dict would drop the
first copy without saying so. Looking one up by name unpacks a single match, so a
duplicate fails the test that assumed there was one.

Added beside the in-memory double rather than replacing it, which is a real cost:
0.06 s for an in-process span test against 0.68 s for the equivalent here, most
of it interpreter startup and server teardown. Worth paying only where the wire
is the thing under test. No new dependency -- opentelemetry-proto already arrives
with the OTLP exporter, and pytest-xdist is already a dev dependency, which is
what lets this reach the multi-process paths next.