### PR TITLE
ci(dependabot): Track Python dependencies with the uv ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
 version: 2
 updates:
-  - package-ecosystem: pip
+  # Only the uv ecosystem keeps uv.lock in sync with pyproject.toml; pip leaves
+  # it stale, which CI rejects because it resolves with UV_LOCKED=1.
+  - package-ecosystem: uv
     directory: /
     schedule:
       interval: daily


### PR DESCRIPTION
The pip ecosystem bumps pyproject.toml but never regenerates uv.lock, so
every dependency pull request fails CI on `UV_LOCKED=1` and has to be
reopened by hand from a non-bot branch — #373/#388 and #456 all died this
way. The uv ecosystem owns pyproject.toml, uv.lock and requirements-uv.txt
in one pull request.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>