### PR TITLE
fix(ci-detection): Strip the `.git` suffix from an HTTPS remote

### DIFF
--- a/pytest_mergify/utils.py
+++ b/pytest_mergify/utils.py
@@ -84,25 +84,29 @@ def get_ci_provider() -> typing.Optional[CIProviderT]:
 
 
 def get_repository_name_from_url(repository_url: str) -> typing.Optional[str]:
-    # Handle SSH Git URLs like git@github.com:owner/repo.git
-    if match := re.match(
-        r"git@[\w.-]+:(?P<full_name>[\w.-]+/[\w.-]+)(?:\.git)?/?$",
-        repository_url,
-    ):
-        full_name = match.group("full_name")
-        # Remove .git suffix if present
-        if full_name.endswith(".git"):
-            full_name = full_name[:-4]
-        return full_name
+    match = (
+        # Handle SSH Git URLs like git@github.com:owner/repo.git
+        re.match(
+            r"git@[\w.-]+:(?P<full_name>[\w.-]+/[\w.-]+)(?:\.git)?/?$",
+            repository_url,
+        )
+        # Handle HTTPS/HTTP URLs like https://github.com/owner/repo (with optional port)
+        or re.match(
+            r"(https?://[\w.-]+(?::\d+)?/)?(?P<full_name>[\w.-]+/[\w.-]+)/?$",
+            repository_url,
+        )
+    )
+    if match is None:
+        return None
 
-    # Handle HTTPS/HTTP URLs like https://github.com/owner/repo (with optional port)
-    if match := re.match(
-        r"(https?://[\w.-]+(?::\d+)?/)?(?P<full_name>[\w.-]+/[\w.-]+)/?$",
-        repository_url,
-    ):
-        return match.group("full_name")
+    full_name = match.group("full_name")
+    # Remove .git suffix if present. Stripped for every URL shape rather than
+    # only for SSH: `git clone` over HTTPS records the suffix too, and the name
+    # is what Mergify files the run under.
+    if full_name.endswith(".git"):
+        full_name = full_name[:-4]
 
-    return None
+    return full_name
 
 
 def get_repository_name_from_env_url(env: str) -> typing.Optional[str]:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,6 +25,15 @@ from pytest_mergify.utils import get_repository_name_from_url, git, is_in_ci
             "my-org.name/my-repo.name",
         ),
         ("git@bitbucket.org:owner123/repo456.git", "owner123/repo456"),
+        # `git clone` over HTTPS records the remote with its `.git` suffix, so
+        # this is what most checkouts actually report.
+        ("https://github.com/owner/repo.git", "owner/repo"),
+        ("http://github.com/owner/repo.git", "owner/repo"),
+        ("https://github.com/owner/repo.git/", "owner/repo"),
+        ("https://git.example.com:8080/owner/repo.git", "owner/repo"),
+        ("owner/repo.git", "owner/repo"),
+        # Only the suffix goes: a name that merely ends in those letters stays.
+        ("https://github.com/owner/repo.github", "owner/repo.github"),
     ],
 )
 def test_get_repository_name_from_url_valid(url: str, expected: str) -> None:


### PR DESCRIPTION
`git clone` over HTTPS records `origin` with its `.git` suffix, so
`remote.origin.url` on a default checkout ends in `.git`. Only the SSH branch
stripped it, leaving the HTTPS branch to report `owner/repo.git` as the
repository name.

Nothing fails when it happens. The run stays green, the spans upload, and the
summary prints a run id -- they are simply filed under a repository Mergify has
no record of, so the results never reach the customer's own repository. It is
the default clone form, and it also feeds Jenkins' `GIT_URL`, Buildkite's
`BUILDKITE_REPO` and CircleCI's `CIRCLE_REPOSITORY_URL`, none of which strip it
either.

Both shapes now go through the same strip, which is where the SSH branch's
existing suffix handling always belonged.