### PR TITLE
feat(ci-detection): Detect CircleCI resource attributes

### DIFF
--- a/pytest_mergify/ci_insights.py
+++ b/pytest_mergify/ci_insights.py
@@ -20,6 +20,7 @@ import pytest_mergify.resources.git as resources_git
 import pytest_mergify.resources.github_actions as resources_gha
 import pytest_mergify.resources.jenkins as resources_jenkins
 import pytest_mergify.resources.buildkite as resources_buildkite
+import pytest_mergify.resources.circleci as resources_circleci
 import pytest_mergify.resources.mergify as resources_mergify
 import pytest_mergify.resources.pytest as resources_pytest
 from pytest_mergify import flaky_detection, utils
@@ -169,6 +170,7 @@ class MergifyCIInsights:
                 resources_gha.GitHubActionsResourceDetector(),
                 resources_jenkins.JenkinsResourceDetector(),
                 resources_buildkite.BuildkiteResourceDetector(),
+                resources_circleci.CircleCIResourceDetector(),
                 resources_pytest.PytestResourceDetector(),
                 resources_mergify.MergifyResourceDetector(),
             ]

--- a/pytest_mergify/resources/circleci.py
+++ b/pytest_mergify/resources/circleci.py
@@ -1,0 +1,36 @@
+from opentelemetry.sdk.resources import Resource, ResourceDetector
+from opentelemetry.semconv._incubating.attributes import cicd_attributes, vcs_attributes
+
+from pytest_mergify import utils
+
+
+class CircleCIResourceDetector(ResourceDetector):
+    """Detects OpenTelemetry Resource attributes for CircleCI."""
+
+    OPENTELEMETRY_CIRCLECI_MAPPING = {
+        # CircleCI publishes no workflow name: `CIRCLE_WORKFLOW_ID` is a UUID
+        # that differs on every run, so it cannot identify the same pipeline
+        # across runs. The job name stands in for both, as the Jenkins detector
+        # already does with `JOB_NAME`. Job names are unique within a project's
+        # config, so the pair still identifies one job run after run.
+        cicd_attributes.CICD_PIPELINE_NAME: (str, "CIRCLE_JOB"),
+        cicd_attributes.CICD_PIPELINE_TASK_NAME: (str, "CIRCLE_JOB"),
+        cicd_attributes.CICD_PIPELINE_RUN_ID: (str, "CIRCLE_WORKFLOW_ID"),
+        "cicd.pipeline.run.url": (str, "CIRCLE_BUILD_URL"),
+        vcs_attributes.VCS_REF_HEAD_NAME: (str, "CIRCLE_BRANCH"),
+        vcs_attributes.VCS_REF_HEAD_REVISION: (str, "CIRCLE_SHA1"),
+        vcs_attributes.VCS_REPOSITORY_URL_FULL: (str, "CIRCLE_REPOSITORY_URL"),
+        "vcs.repository.name": (
+            str,
+            lambda: utils.get_repository_name_from_env_url("CIRCLE_REPOSITORY_URL"),
+        ),
+        # No base branch is published either, so a pull request run is not
+        # distinguishable from a branch run here. Flaky detection reads that
+        # absence as a push run and stays in `unhealthy` mode.
+    }
+
+    def detect(self) -> Resource:
+        if utils.get_ci_provider() != "circleci":
+            return Resource({})
+
+        return Resource(utils.get_attributes(self.OPENTELEMETRY_CIRCLECI_MAPPING))

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -144,6 +144,47 @@ def test_span_jenkins(
 
 
 @mock.patch("pytest_mergify.utils.git", return_value=None)
+def test_span_circleci(
+    git: mock.Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    pytester_with_spans: conftest.PytesterWithSpanT,
+) -> None:
+    # `CIRCLECI` was listed as a supported provider with no detector behind it,
+    # so a run uploaded a provider name and nothing else it needed.
+    monkeypatch.setenv("GITHUB_ACTIONS", "false")
+    monkeypatch.setenv("CIRCLECI", "true")
+    monkeypatch.setenv("CIRCLE_JOB", "unit-tests")
+    monkeypatch.setenv("CIRCLE_WORKFLOW_ID", "8f2a1c44-0b6e-4c7a-9d3f-1e5b7a9c2d40")
+    monkeypatch.setenv(
+        "CIRCLE_BUILD_URL", "https://circleci.com/gh/Mergifyio/pytest-mergify/42"
+    )
+    monkeypatch.setenv("CIRCLE_BRANCH", "main")
+    monkeypatch.setenv("CIRCLE_SHA1", "1860cf377dd5610e256ff52e47cf38816cc04549")
+    monkeypatch.setenv(
+        "CIRCLE_REPOSITORY_URL", "https://github.com/Mergifyio/pytest-mergify"
+    )
+
+    result, spans = pytester_with_spans()
+
+    assert spans is not None
+    for span in spans.values():
+        assert span.resource.attributes["cicd.provider.name"] == "circleci"
+        assert span.resource.attributes["vcs.repository.name"] == (
+            "Mergifyio/pytest-mergify"
+        )
+        assert span.resource.attributes["vcs.ref.head.name"] == "main"
+        assert span.resource.attributes["vcs.ref.head.revision"] == (
+            "1860cf377dd5610e256ff52e47cf38816cc04549"
+        )
+        assert span.resource.attributes["cicd.pipeline.run.id"] == (
+            "8f2a1c44-0b6e-4c7a-9d3f-1e5b7a9c2d40"
+        )
+        # CircleCI publishes no workflow name, so the job name serves as both.
+        assert span.resource.attributes["cicd.pipeline.name"] == "unit-tests"
+        assert span.resource.attributes["cicd.pipeline.task.name"] == "unit-tests"
+
+
+@mock.patch("pytest_mergify.utils.git", return_value=None)
 def test_span_git(
     git: mock.Mock,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
`CIRCLECI` has been in `SUPPORTED_CIs` since the beginning with no detector
behind it. A CircleCI run therefore uploaded `cicd.provider.name: circleci` and
a repository name, and nothing else: no branch, no revision, no pipeline, no
job.

Nothing reported a problem, because nothing failed. Quarantine needs a branch
name and stayed off; test selection needs branch, revision, pipeline and job and
stayed off; both are gated on attributes being present, so their absence read as
"not configured" rather than "not collected". The run stayed green and printed a
run id the whole time. Listing a provider the plugin cannot describe is a
promise the rest of the code silently declines to keep.

CircleCI publishes no workflow name -- `CIRCLE_WORKFLOW_ID` is a per-run UUID,
so it cannot identify the same pipeline twice. `CIRCLE_JOB` fills both
`cicd.pipeline.name` and `cicd.pipeline.task.name`, which is what the Jenkins
detector already does with `JOB_NAME`; job names are unique within a project's
config, so the pair still names one job across runs, which is what quarantine
and selection match on.

It publishes no base branch either, so a pull request is indistinguishable from
a branch build here and flaky detection stays in `unhealthy` mode. That is a
real gap, recorded rather than papered over.

The git mapping is not folded in as Jenkins and Buildkite do it: the git
detector is registered ahead of this one and its values are overridden by
whatever CircleCI supplies, so repeating it here would only duplicate the
fallback.