### PR TITLE
test(xdist): Observe what a distributed run puts on the wire

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -292,6 +292,33 @@ def otlp_collector() -> typing.Generator[OTLPCollector, None, None]:
 
 
 @pytest.fixture
+def uploading_collector(
+    # Requested so that the API url below is set after the autouse fixture that
+    # points it elsewhere, rather than merely alongside it.
+    set_api_url: None,
+    monkeypatch: pytest.MonkeyPatch,
+    otlp_collector: OTLPCollector,
+) -> OTLPCollector:
+    """
+    A collector the plugin will genuinely upload to.
+
+    The uploading exporter is only built for a CI run carrying a token and a
+    repository the plugin can name, so anything short of the whole set leaves
+    the collector correct and empty -- which reads as a passing assertion.
+    """
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "Mergifyio/pytest-mergify")
+    monkeypatch.setenv("MERGIFY_TOKEN", "token")
+    monkeypatch.setenv("MERGIFY_API_URL", otlp_collector.url)
+    # Both of these swap the exporter for one that uploads nothing.
+    monkeypatch.delenv("_PYTEST_MERGIFY_TEST", raising=False)
+    monkeypatch.delenv("PYTEST_MERGIFY_DEBUG", raising=False)
+
+    return otlp_collector
+
+
+@pytest.fixture
 def http_server(request: pytest.FixtureRequest) -> typing.Generator[str, None, None]:
     # Allow parameterization of the response code via request.param.
     response_code = getattr(request, "param", 200)

--- a/tests/test_uploaded_spans.py
+++ b/tests/test_uploaded_spans.py
@@ -1,38 +1,21 @@
 import re
 
 import _pytest.pytester
-import pytest
 
 from tests import conftest
 
 
-def _configure_upload(
-    monkeypatch: pytest.MonkeyPatch,
-    collector: conftest.OTLPCollector,
-) -> None:
-    monkeypatch.setenv("CI", "true")
-    monkeypatch.setenv("GITHUB_ACTIONS", "true")
-    monkeypatch.setenv("GITHUB_REPOSITORY", "Mergifyio/pytest-mergify")
-    monkeypatch.setenv("MERGIFY_TOKEN", "token")
-    monkeypatch.setenv("MERGIFY_API_URL", collector.url)
-    # Both of these swap the exporter for one that uploads nothing.
-    monkeypatch.delenv("_PYTEST_MERGIFY_TEST", raising=False)
-    monkeypatch.delenv("PYTEST_MERGIFY_DEBUG", raising=False)
-
-
 def test_a_run_uploads_its_spans(
     pytester: _pytest.pytester.Pytester,
-    monkeypatch: pytest.MonkeyPatch,
-    otlp_collector: conftest.OTLPCollector,
+    uploading_collector: conftest.OTLPCollector,
 ) -> None:
-    _configure_upload(monkeypatch, otlp_collector)
     pytester.makepyfile("def test_pass(): pass")
 
     result = pytester.runpytest_subprocess()
 
     result.assert_outcomes(passed=1)
-    assert len(otlp_collector.batches) == 1
-    assert otlp_collector.span_names == {
+    assert len(uploading_collector.batches) == 1
+    assert uploading_collector.span_names == {
         "pytest session start",
         "test_a_run_uploads_its_spans.py::test_pass",
     }
@@ -40,12 +23,10 @@ def test_a_run_uploads_its_spans(
 
 def test_an_uploaded_span_carries_its_attributes(
     pytester: _pytest.pytester.Pytester,
-    monkeypatch: pytest.MonkeyPatch,
-    otlp_collector: conftest.OTLPCollector,
+    uploading_collector: conftest.OTLPCollector,
 ) -> None:
     # Asserting on the decoded payload rather than on terminal text: a run can
     # print a run id and still have uploaded nothing.
-    _configure_upload(monkeypatch, otlp_collector)
     pytester.makepyfile("def test_pass(): pass")
 
     result = pytester.runpytest_subprocess()
@@ -53,7 +34,7 @@ def test_an_uploaded_span_carries_its_attributes(
     # Asserted before the payload, so a run that died on the way to uploading
     # reads as the failure it is rather than as a missing key.
     result.assert_outcomes(passed=1)
-    (batch,) = otlp_collector.batches
+    (batch,) = uploading_collector.batches
     span = batch.span("test_an_uploaded_span_carries_its_attributes.py::test_pass")
 
     assert span.attributes["test.case.result.status"] == "passed"
@@ -66,3 +47,38 @@ def test_an_uploaded_span_carries_its_attributes(
     printed_run_id = re.search(r"MERGIFY_TEST_RUN_ID=(\w+)", result.stdout.str())
     assert printed_run_id is not None
     assert batch.resource_attributes["test.run.id"] == printed_run_id.group(1)
+
+
+def test_a_distributed_run_uploads_each_test_once(
+    pytester: _pytest.pytester.Pytester,
+    uploading_collector: conftest.OTLPCollector,
+) -> None:
+    """
+    Under xdist every worker uploads on its own, from its own process.
+
+    Nothing the controller reports can show a test whose span never left the
+    worker that ran it, nor one that two of them each sent home, so the wire is
+    the only place the split is observable.
+    """
+    pytester.makepyfile(
+        """
+        def test_a(): pass
+        def test_b(): pass
+        def test_c(): pass
+        def test_d(): pass
+        """
+    )
+
+    result = pytester.runpytest_subprocess("-n", "2")
+
+    result.assert_outcomes(passed=4)
+    uploaded = [
+        span.name
+        for batch in uploading_collector.batches
+        for span in batch.spans
+        if span.name != "pytest session start"
+    ]
+    assert sorted(uploaded) == [
+        f"test_a_distributed_run_uploads_each_test_once.py::test_{name}"
+        for name in ("a", "b", "c", "d")
+    ]


### PR DESCRIPTION
Every xdist worker exports from its own process, so the in-process span
exporter -- and anything the controller prints -- is blind to a test whose
span never left the worker that ran it, or that two workers each sent home.
Nothing covered that: the plugin's only multi-process assertions ran with a
single process.

Promote the upload environment `test_uploaded_spans` kept to itself into a
fixture, so a test wanting the real wire asks for one thing rather than
restating seven environment variables, and cover `-n 2` with it.